### PR TITLE
Fix media v10 GetStreamUri

### DIFF
--- a/lib/media/ver10/get_stream_uri.ex
+++ b/lib/media/ver10/get_stream_uri.ex
@@ -7,9 +7,17 @@ defmodule Onvif.Media.Ver10.GetStreamUri do
   def request(uri, auth \\ :xml_auth, args),
     do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
 
-  def request_body(profile_token) do
+  def request_body(profile_token, stream_type, protocol) do
     element(:"s:Body", [
-      element(:"tds:GetStreamUri", [element(:"tds:ProfileToken", profile_token)])
+      element(:"trt:GetStreamUri", [
+        element(:"trt:StreamSetup", [
+          element(:"tt:Stream", stream_type),
+          element(:"tt:Transport", [
+            element(:"tt:Protocol", protocol)
+          ])
+        ]),
+        element(:"trt:ProfileToken", profile_token)
+      ])
     ])
   end
 

--- a/lib/media/ver10/get_stream_uri.ex
+++ b/lib/media/ver10/get_stream_uri.ex
@@ -2,12 +2,16 @@ defmodule Onvif.Media.Ver10.GetStreamUri do
   import SweetXml
   import XmlBuilder
 
+  @transport_protocols ["UDP", "TCP", "RTSP", "HTTP"]
+  @stream_types ["RTP-Unicast", "RTP-Multicast"]
+
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetStreamUri"
 
   def request(uri, auth \\ :xml_auth, args),
     do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
 
-  def request_body(profile_token, stream_type, protocol) do
+  def request_body(profile_token, stream_type, protocol)
+      when stream_type in @stream_types and protocol in @transport_protocols do
     element(:"s:Body", [
       element(:"trt:GetStreamUri", [
         element(:"trt:StreamSetup", [

--- a/lib/media/ver10/get_stream_uri.ex
+++ b/lib/media/ver10/get_stream_uri.ex
@@ -2,16 +2,12 @@ defmodule Onvif.Media.Ver10.GetStreamUri do
   import SweetXml
   import XmlBuilder
 
-  @transport_protocols ["UDP", "TCP", "RTSP", "HTTP"]
-  @stream_types ["RTP-Unicast", "RTP-Multicast"]
-
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetStreamUri"
 
   def request(uri, auth \\ :xml_auth, args),
     do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
 
-  def request_body(profile_token, stream_type \\ "RTP-Unicast", protocol \\ "RTSP")
-      when stream_type in @stream_types and protocol in @transport_protocols do
+  def request_body(profile_token, stream_type \\ "RTP-Unicast", protocol \\ "RTSP") do
     element(:"s:Body", [
       element(:"trt:GetStreamUri", [
         element(:"trt:StreamSetup", [

--- a/lib/media/ver10/get_stream_uri.ex
+++ b/lib/media/ver10/get_stream_uri.ex
@@ -10,7 +10,7 @@ defmodule Onvif.Media.Ver10.GetStreamUri do
   def request(uri, auth \\ :xml_auth, args),
     do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
 
-  def request_body(profile_token, stream_type, protocol)
+  def request_body(profile_token, stream_type \\ "RTP-Unicast", protocol \\ "RTSP")
       when stream_type in @stream_types and protocol in @transport_protocols do
     element(:"s:Body", [
       element(:"trt:GetStreamUri", [


### PR DESCRIPTION
- According to the [spec](https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetStreamUri), the `GetStreamUri` requires two more mandatory attributes i.e. stream and transport.
- Added the the same. The stream should be either "RTP-Unicast" or "RTP-Multicast". Transport should be from "UDP", "TCP", "RTSP" and "HTTP".