### PR TITLE
Add status code to error

### DIFF
--- a/lib/devices/devices.ex
+++ b/lib/devices/devices.ex
@@ -34,9 +34,17 @@ defmodule Onvif.Devices do
     operation.response(body)
   end
 
-  defp parse_response({:ok, response}, operation),
-    do: {:error, "Received #{response.status} from #{operation}"}
+  defp parse_response({:ok, %{status: status_code, body: body}}, operation)
+       when status_code >= 400,
+       do:
+         {:error,
+          %{
+            status: status_code,
+            reason: "Received #{status_code} from #{operation}",
+            response: body
+          }}
 
-  defp parse_response({:error, _response}, operation),
-    do: {:error, "Error performing #{operation}"}
+  defp parse_response({:error, response}, operation) do
+    {:error, %{status: nil, reason: "Error performing #{operation}", response: response}}
+  end
 end

--- a/lib/media/ver10/media.ex
+++ b/lib/media/ver10/media.ex
@@ -34,9 +34,17 @@ defmodule Onvif.Media.Ver10.Media do
     operation.response(body)
   end
 
-  defp parse_response({:ok, response}, operation),
-    do: {:error, "Received #{response.status} from #{operation}"}
+  defp parse_response({:ok, %{status: status_code, body: body}}, operation)
+       when status_code >= 400,
+       do:
+         {:error,
+          %{
+            status: status_code,
+            reason: "Received #{status_code} from #{operation}",
+            response: body
+          }}
 
-  defp parse_response({:error, _response}, operation),
-    do: {:error, "Error performing #{operation}"}
+  defp parse_response({:error, response}, operation) do
+    {:error, %{status: nil, reason: "Error performing #{operation}", response: response}}
+  end
 end

--- a/lib/media/ver20/media.ex
+++ b/lib/media/ver20/media.ex
@@ -33,9 +33,17 @@ defmodule Onvif.Media.Ver20.Media do
     operation.response(body)
   end
 
-  defp parse_response({:ok, response}, operation),
-    do: {:error, "Received #{response.status} from #{operation}"}
+  defp parse_response({:ok, %{status: status_code, body: body}}, operation)
+       when status_code >= 400,
+       do:
+         {:error,
+          %{
+            status: status_code,
+            reason: "Received #{status_code} from #{operation}",
+            response: body
+          }}
 
-  defp parse_response({:error, _response}, operation),
-    do: {:error, "Error performing #{operation}"}
+  defp parse_response({:error, response}, operation) do
+    {:error, %{status: nil, reason: "Error performing #{operation}", response: response}}
+  end
 end


### PR DESCRIPTION
- Added status code and original xml response to the error data. So the caller can error handle based on the status code and xml response.