### PR TITLE
Add support to init onvif device from prob match

### DIFF
--- a/lib/api.ex
+++ b/lib/api.ex
@@ -1,15 +1,17 @@
 defmodule Onvif.API do
   @moduledoc false
 
-  @spec client(String.t(), :no_auth | :basic_auth | :xml_auth | :digest_auth) :: Tesla.Client.t()
-  def client(uri, auth \\ :xml_auth) do
+  @spec client(Onvif.Device.t(), Keyword.t()) :: Tesla.Client.t()
+  def client(device, opts \\ [service_path: :device_service_path]) do
     adapter = {Tesla.Adapter.Finch, name: Onvif.Finch}
+    service_path = Map.fetch!(device, opts[:service_path])
+    uri = device.address <> service_path
     parsed_uri = URI.parse(uri)
     no_userinfo_uri = %URI{parsed_uri | userinfo: nil} |> URI.to_string()
 
     middleware = [
       {Tesla.Middleware.BaseUrl, no_userinfo_uri},
-      auth_function(auth, parsed_uri),
+      auth_function(device),
       {Tesla.Middleware.Logger, log_level: :info},
       {Tesla.Middleware.Headers,
        [
@@ -20,16 +22,14 @@ defmodule Onvif.API do
     Tesla.client(middleware, adapter)
   end
 
-  defp auth_function(:no_auth, _), do: Onvif.Middleware.NoAuth
-  defp auth_function(:basic_auth, %URI{} = uri), do: {Onvif.Middleware.PlainAuth, get_auth(uri)}
-  defp auth_function(:xml_auth, %URI{} = uri), do: {Onvif.Middleware.XmlAuth, get_auth(uri)}
-  defp auth_function(:digest_auth, %URI{} = uri), do: {Onvif.Middleware.DigestAuth, get_auth(uri)}
+  defp auth_function(%{auth_type: :no_auth}), do: Onvif.Middleware.NoAuth
 
-  @spec get_auth(URI.t()) :: keyword()
-  defp get_auth(%URI{userinfo: userinfo}) when is_binary(userinfo) do
-    [username, password] = String.split(userinfo, ":", parts: 2)
-    [username: URI.decode_www_form(username), password: URI.decode_www_form(password)]
-  end
+  defp auth_function(%{auth_type: :basic_auth} = device),
+    do: {Onvif.Middleware.PlainAuth, device: device}
 
-  defp get_auth(_uri), do: [username: nil, password: nil]
+  defp auth_function(%{auth_type: :xml_auth} = device),
+    do: {Onvif.Middleware.XmlAuth, device: device}
+
+  defp auth_function(%{auth_type: :digest_auth} = device),
+    do: {Onvif.Middleware.DigestAuth, device: device}
 end

--- a/lib/device.ex
+++ b/lib/device.ex
@@ -54,6 +54,7 @@ defmodule Onvif.Device do
       probe_match.address
       |> get_address(prefer_ipv6?, prefer_https?)
       |> URI.parse()
+      |> Map.put(:path, "")
       |> Map.put(:userinfo, "#{username}:#{password}")
 
     device = %Device{

--- a/lib/device.ex
+++ b/lib/device.ex
@@ -123,7 +123,7 @@ defmodule Onvif.Device do
   end
 
   defp get_date_time(device) do
-    with {:ok, res} <- Onvif.Devices.GetSystemDateAndTime.request(device.address) do
+    with {:ok, res} <- Onvif.Devices.GetSystemDateAndTime.request(device) do
       updated_device = %{device | time_diff_from_system_secs: res.current_diff, ntp: res.ntp}
       {:ok, updated_device}
     end
@@ -135,19 +135,18 @@ defmodule Onvif.Device do
     else
       [auth_type | rest] = auth_types
 
-      case get_device_information(device, auth_type) do
+      guess_device = %{device | auth_type: auth_type}
+
+      case get_device_information(guess_device) do
         {:ok, %Device{} = updated_device} -> {:ok, %{updated_device | auth_type: auth_type}}
         {:error, _res} -> guess_auth(device, rest)
       end
     end
   end
 
-  defp get_device_information(device, auth_type) do
+  defp get_device_information(device) do
     with {:ok, res} <-
-           Onvif.Devices.GetDeviceInformation.request(
-             device.address,
-             auth_type
-           ) do
+           Onvif.Devices.GetDeviceInformation.request(device) do
       {:ok,
        %{
          device
@@ -161,10 +160,7 @@ defmodule Onvif.Device do
 
   defp get_services(device) do
     with {:ok, services} <-
-           Onvif.Devices.GetServices.request(
-             device.address,
-             device.auth_type
-           ) do
+           Onvif.Devices.GetServices.request(device) do
       Map.put(device, :services, services)
     end
   end

--- a/lib/device.ex
+++ b/lib/device.ex
@@ -160,15 +160,11 @@ defmodule Onvif.Device do
   end
 
   defp get_services(device) do
-    with {:ok, res} <-
+    with {:ok, services} <-
            Onvif.Devices.GetServices.request(
              device.address,
              device.auth_type
            ) do
-      services =
-        res
-        |> Enum.map(&elem(&1, 1))
-
       Map.put(device, :services, services)
     end
   end

--- a/lib/device.ex
+++ b/lib/device.ex
@@ -1,4 +1,7 @@
 defmodule Onvif.Device do
+  alias Onvif.Device
+  alias Onvif.Discovery.Probe
+
   @enforce_keys [:username, :password, :address]
 
   @type t :: %__MODULE__{}
@@ -19,4 +22,128 @@ defmodule Onvif.Device do
                 supports_media2?: false,
                 device_service_path: "/onvif/device_service"
               ]
+
+  @spec init(Onvif.Discovery.Probe.t(), String.t(), String.t(), boolean, boolean) ::
+          {:error, any()}
+          | %Device{}
+  def init(%Probe{} = probe_match, username, password, use_https? \\ false, use_ipv6? \\ false) do
+    with {:ok, device} <-
+           device_from_probe_match(probe_match, username, password, use_https?, use_ipv6?),
+         {:ok, device_with_datetime} <- get_date_time(device),
+         {:ok, updated_device} <- guess_auth(device_with_datetime) do
+      updated_device
+      |> get_services()
+      |> set_media_service_path()
+    end
+  end
+
+  defp device_from_probe_match(%Probe{} = probe_match, username, password, use_https?, use_ipv6?) do
+    scheme = if use_https?, do: "https", else: "http"
+
+    uri =
+      probe_match.address
+      |> get_address(use_ipv6?)
+      |> URI.parse()
+      |> Map.put(:scheme, scheme)
+      |> Map.put(:userinfo, "#{username}:#{password}")
+
+    is_nvr? = if "tds:Device" in probe_match.types, do: false, else: true
+
+    device = %Device{
+      username: username,
+      password: password,
+      ip: URI.to_string(uri),
+      port: uri.port,
+      scopes: probe_match.scopes,
+      is_nvr?: is_nvr?
+    }
+
+    {:ok, device}
+  end
+
+  defp get_address(addresses, use_ipv6?) do
+    ipv6_address =
+      Enum.find(addresses, fn address ->
+        uri = URI.parse(address)
+        String.contains?(uri.host, ":")
+      end)
+
+    if use_ipv6? and !is_nil(ipv6_address) do
+      ipv6_address
+    else
+      Enum.at(addresses, 0)
+    end
+  end
+
+  defp get_date_time(device) do
+    with {:ok, res} <- Onvif.Devices.GetSystemDateAndTime.request(device.ip) do
+      {:ok, Map.merge(device, Map.from_struct(res))}
+    end
+  end
+
+  defp guess_auth(device, auth_types \\ [:xml_auth, :digest_auth, :basic_auth, :no_auth]) do
+    if Enum.count(auth_types) == 0 do
+      {:error, "Invalid credentials"}
+    else
+      [auth_type | rest] = auth_types
+
+      case get_device_information(device, auth_type) do
+        {:ok, %Device{} = updated_device} -> {:ok, Map.put(updated_device, :auth_type, auth_type)}
+        {:error, _res} -> guess_auth(device, rest)
+      end
+    end
+  end
+
+  defp get_device_information(device, auth_type) do
+    with {:ok, res} <-
+           Onvif.Devices.GetDeviceInformation.request(
+             device.ip,
+             auth_type
+           ) do
+      {:ok, Map.merge(device, Map.from_struct(res))}
+    end
+  end
+
+  defp get_services(device) do
+    with {:ok, res} <-
+           Onvif.Devices.GetServices.request(
+             device.ip,
+             device.auth_type
+           ) do
+      services =
+        res
+        |> Enum.map(&elem(&1, 1))
+
+      Map.put(device, :services, services)
+    end
+  end
+
+  defp set_media_service_path(device) do
+    case get_media_ver20_service_path(device.services) do
+      nil ->
+        path = get_media_ver10_service_path(device.services)
+        Map.put(device, :media_service_path, path)
+
+      path ->
+        device
+        |> Map.put(:media_service_path, path)
+        |> Map.put(:supports_media2?, true)
+    end
+  end
+
+  defp get_media_ver20_service_path(services) do
+    services
+    |> Enum.find(&String.contains?(&1.namespace, "ver20/media"))
+    |> then(& &1.xaddr)
+    |> URI.parse()
+    |> Map.get(:path)
+  end
+
+  defp get_media_ver10_service_path(services) do
+    services
+    |> Enum.find(&String.contains?(&1.namespace, "ver10/media"))
+    |> then(& &1.xaddr)
+    |> URI.parse()
+    |> Map.get(:path)
+  end
 end

--- a/lib/devices/devices.ex
+++ b/lib/devices/devices.ex
@@ -16,8 +16,8 @@ defmodule Onvif.Devices do
     content = generate_content(operation)
     soap_action = operation.soap_action()
 
-    (device.address <> device.device_service_path)
-    |> Onvif.API.client(device.auth_type)
+    device
+    |> Onvif.API.client()
     |> Tesla.request(
       method: :post,
       headers: [{"Content-Type", "application/soap+xml"}, {"SOAPAction", soap_action}],

--- a/lib/devices/get_services.ex
+++ b/lib/devices/get_services.ex
@@ -1,5 +1,5 @@
 defmodule Onvif.Devices.GetServices do
-  # import SweetXml
+  import SweetXml
   import XmlBuilder
 
   alias Onvif.Device
@@ -14,6 +14,18 @@ defmodule Onvif.Devices.GetServices do
   end
 
   def response(xml_response_body) do
-    xml_response_body
+    result =
+      xml_response_body
+      |> parse(namespace_conformant: true, quiet: true)
+      |> xpath(
+        ~x"//s:Envelope/s:Body/tds:GetServicesResponse/tds:Service"el
+        |> add_namespace("s", "http://www.w3.org/2003/05/soap-envelope")
+        |> add_namespace("tds", "http://www.onvif.org/ver10/device/wsdl")
+        |> add_namespace("tt", "http://www.onvif.org/ver10/schema")
+      )
+      |> Enum.map(&Onvif.Device.Service.parse/1)
+      |> Enum.map(&Onvif.Device.Service.to_struct/1)
+
+    {:ok, result}
   end
 end

--- a/lib/devices/service.ex
+++ b/lib/devices/service.ex
@@ -23,8 +23,8 @@ defmodule Onvif.Device.Service do
         minor: ~x"./tds:Version/tt:Minor/text()"s
       )
 
-    xmap(
-      doc,
+    doc
+    |> xmap(
       namespace: ~x"./tds:Namespace/text()"s,
       xaddr: ~x"./tds:XAddr/text()"s
     )
@@ -38,7 +38,6 @@ defmodule Onvif.Device.Service do
   end
 
   def changeset(module, attrs) do
-    module
-    |> cast(attrs, @profile_permitted)
+    cast(module, attrs, @profile_permitted)
   end
 end

--- a/lib/devices/service.ex
+++ b/lib/devices/service.ex
@@ -3,6 +3,7 @@ defmodule Onvif.Device.Service do
   A media profile
   """
 
+  require Logger
   use Ecto.Schema
   import Ecto.Changeset
   import SweetXml
@@ -35,6 +36,10 @@ defmodule Onvif.Device.Service do
     %__MODULE__{}
     |> changeset(parsed)
     |> apply_action(:validate)
+    |> case do
+      {:ok, data} -> data
+      {:error, _changeset} -> Logger.error("Error in validating device service changeset")
+    end
   end
 
   def changeset(module, attrs) do

--- a/lib/devices/service.ex
+++ b/lib/devices/service.ex
@@ -1,0 +1,44 @@
+defmodule Onvif.Device.Service do
+  @moduledoc """
+  A media profile
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  import SweetXml
+
+  @profile_permitted [:namespace, :xaddr, :version]
+
+  @primary_key false
+  embedded_schema do
+    field(:namespace, :string)
+    field(:xaddr, :string)
+    field(:version, :string)
+  end
+
+  def parse(doc) do
+    version =
+      xmap(doc,
+        major: ~x"./tds:Version/tt:Major/text()"s,
+        minor: ~x"./tds:Version/tt:Minor/text()"s
+      )
+
+    xmap(
+      doc,
+      namespace: ~x"./tds:Namespace/text()"s,
+      xaddr: ~x"./tds:XAddr/text()"s
+    )
+    |> Map.put(:version, "#{version.major}.#{version.minor}")
+  end
+
+  def to_struct(parsed) do
+    %__MODULE__{}
+    |> changeset(parsed)
+    |> apply_action(:validate)
+  end
+
+  def changeset(module, attrs) do
+    module
+    |> cast(attrs, @profile_permitted)
+  end
+end

--- a/lib/media/ver10/media.ex
+++ b/lib/media/ver10/media.ex
@@ -18,8 +18,8 @@ defmodule Onvif.Media.Ver10.Media do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
-    (device.address <> device.media_service_path)
-    |> Onvif.API.client(device.auth_type)
+    device
+    |> Onvif.API.client(service_path: :media_service_path)
     |> Tesla.request(
       method: :post,
       headers: [{"Content-Type", "application/soap+xml"}, {"SOAPAction", soap_action}],

--- a/lib/media/ver10/media.ex
+++ b/lib/media/ver10/media.ex
@@ -9,7 +9,8 @@ defmodule Onvif.Media.Ver10.Media do
   alias Onvif.Device
 
   @namespaces [
-    "xmlns:trt": "http://www.onvif.org/ver10/media/wsdl"
+    "xmlns:trt": "http://www.onvif.org/ver10/media/wsdl",
+    "xmlns:tt": "http://www.onvif.org/ver10/schema"
   ]
 
   @spec request(Device.t(), list, module()) :: {:ok, any} | {:error, map()}

--- a/lib/media/ver20/media.ex
+++ b/lib/media/ver20/media.ex
@@ -18,8 +18,8 @@ defmodule Onvif.Media.Ver20.Media do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
-    (device.address <> device.media_service_path)
-    |> Onvif.API.client(device.auth_type)
+    device
+    |> Onvif.API.client(service_path: :media_service_path)
     |> Tesla.request(
       method: :post,
       headers: [{"Content-Type", "application/soap+xml"}, {"SOAPAction", soap_action}],

--- a/lib/middleware/digest_auth.ex
+++ b/lib/middleware/digest_auth.ex
@@ -47,10 +47,12 @@ defmodule Onvif.Middleware.DigestAuth do
              headers: env.headers,
              body: env.body
            ) do
+      device = Keyword.fetch!(opts, :device)
+
       {:ok,
        %{
-         username: opts[:username] || "",
-         password: opts[:password] || "",
+         username: device.username || "",
+         password: device.password || "",
          path: URI.parse(env.url).path,
          auth:
            unauthorized_response

--- a/lib/middleware/plain_auth.ex
+++ b/lib/middleware/plain_auth.ex
@@ -38,8 +38,7 @@ defmodule Onvif.Middleware.PlainAuth do
     end
   end
 
-  defp generate_xml_auth_header(username: username, password: password)
-       when is_binary(username) and is_binary(password) do
+  defp generate_xml_auth_header(device: device) do
     element(
       :"s:Header",
       [
@@ -49,14 +48,14 @@ defmodule Onvif.Middleware.PlainAuth do
             element(
               :"wsse:UsernameToken",
               [
-                element(:"wsse:Username", username),
+                element(:"wsse:Username", device.username),
                 element(
                   :"wsse:Password",
                   %{
                     "Type" =>
                       "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"
                   },
-                  password
+                  device.password
                 )
               ]
             )

--- a/lib/middleware/xml_auth.ex
+++ b/lib/middleware/xml_auth.ex
@@ -25,7 +25,7 @@ defmodule Onvif.Middleware.XmlAuth do
   end
 
   defp inject_xml_auth_header(env, opts) do
-    case generate_xml_auth_header(env.url, opts) do
+    case generate_xml_auth_header(opts) do
       nil ->
         generate(
           element(:"s:Envelope", @standard_namespaces ++ env.body.namespaces, [env.body.content])
@@ -42,9 +42,7 @@ defmodule Onvif.Middleware.XmlAuth do
     end
   end
 
-  defp generate_xml_auth_header(url, username: username, password: password)
-       when is_binary(username) and is_binary(password) do
-    device = %Onvif.Device{username: username, password: password, address: url}
+  defp generate_xml_auth_header(device: device) do
     {:ok, system_date} = Onvif.Devices.GetSystemDateAndTime.request(device)
 
     created_at =
@@ -52,7 +50,7 @@ defmodule Onvif.Middleware.XmlAuth do
 
     nonce_bytes = :rand.bytes(@nonce_bytesize)
     nonce = Base.encode64(nonce_bytes)
-    digest = :sha |> :crypto.hash(nonce_bytes <> created_at <> password) |> Base.encode64()
+    digest = :sha |> :crypto.hash(nonce_bytes <> created_at <> device.password) |> Base.encode64()
 
     element(
       :"s:Header",
@@ -64,7 +62,7 @@ defmodule Onvif.Middleware.XmlAuth do
             element(
               :UsernameToken,
               [
-                element(:Username, username),
+                element(:Username, device.username),
                 element(
                   :Password,
                   %{
@@ -90,5 +88,5 @@ defmodule Onvif.Middleware.XmlAuth do
     )
   end
 
-  defp generate_xml_auth_header(_uri, _opt), do: nil
+  defp generate_xml_auth_header(_uri), do: nil
 end

--- a/lib/middleware/xml_auth.ex
+++ b/lib/middleware/xml_auth.ex
@@ -44,12 +44,8 @@ defmodule Onvif.Middleware.XmlAuth do
 
   defp generate_xml_auth_header(url, username: username, password: password)
        when is_binary(username) and is_binary(password) do
-    uri = URI.parse(url)
-
-    {:ok, system_date} =
-      %URI{uri | userinfo: "", path: ""}
-      |> URI.to_string()
-      |> Onvif.Devices.GetSystemDateAndTime.request()
+    device = %Onvif.Device{username: username, password: password, address: url}
+    {:ok, system_date} = Onvif.Devices.GetSystemDateAndTime.request(device)
 
     created_at =
       DateTime.utc_now() |> DateTime.add(system_date.current_diff) |> DateTime.to_iso8601()


### PR DESCRIPTION
- Given the probe match and credentials, this will get the device's datetime, figure out the supported auth, device information, and supported ONVIF services.
- After this, the workflow will be like
  - The user users `Onvif.Discover.probe` which will return list of probe matches
  - The user can call `Onvif.Device.init` for each probe match to get the device data populated. This populated ONVIF device will act as a base for the user's custom workflow i.e. adding profiles, getting snapshot, getting rtsp url ..etc.