### PR TITLE
Remove hardcoded media service path

### DIFF
--- a/lib/media/ver10/media.ex
+++ b/lib/media/ver10/media.ex
@@ -6,10 +6,9 @@ defmodule Onvif.Media.Ver10.Media do
   """
   require Logger
 
-  @endpoint "/onvif/media_service"
-
   @namespaces [
-    "xmlns:trt": "http://www.onvif.org/ver10/media/wsdl"
+    "xmlns:trt": "http://www.onvif.org/ver10/media/wsdl",
+    "xmlns:tt": "http://www.onvif.org/ver10/schema"
   ]
 
   @spec request(String.t(), list, :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
@@ -18,7 +17,7 @@ defmodule Onvif.Media.Ver10.Media do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
-    (uri <> @endpoint)
+    uri
     |> Onvif.API.client(auth)
     |> Tesla.request(
       method: :post,

--- a/lib/media/ver20/media.ex
+++ b/lib/media/ver20/media.ex
@@ -6,8 +6,6 @@ defmodule Onvif.Media.Ver20.Media do
   """
   require Logger
 
-  @endpoint "/onvif/media"
-
   @namespaces [
     "xmlns:tr2": "http://www.onvif.org/ver20/media/wsdl",
     "xmlns:tt": "http://www.onvif.org/ver10/schema"
@@ -17,7 +15,7 @@ defmodule Onvif.Media.Ver20.Media do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
-    (uri <> @endpoint)
+    uri
     |> Onvif.API.client(auth)
     |> Tesla.request(
       method: :post,


### PR DESCRIPTION
- ONVIF spec guarantees only the device service path as `/onvif/device_service`. For media and other service, the manufacturers are allowed to use any path.
- These paths can be obtained by using the device service's `GetServices` call.
- So removed the hardcoded path here so the user can append the path when using the media service API.
- This also fixes a namespace issue in media ver10.