### PR TITLE
Use device struct in device service API

### DIFF
--- a/lib/device.ex
+++ b/lib/device.ex
@@ -1,6 +1,8 @@
 defmodule Onvif.Device do
   @enforce_keys [:username, :password, :address]
 
+  @type t :: %__MODULE__{}
+
   defstruct @enforce_keys ++
               [
                 :auth_type,

--- a/lib/devices/devices.ex
+++ b/lib/devices/devices.ex
@@ -5,20 +5,19 @@ defmodule Onvif.Devices do
     https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl
   """
   require Logger
-
-  @endpoint "/onvif/device_service"
+  alias Onvif.Device
 
   @namespaces [
     "xmlns:tds": "http://www.onvif.org/ver10/device/wsdl"
   ]
 
-  @spec request(String.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
-          {:ok, any} | {:error, String.t()}
-  def request(uri, auth \\ :xml_auth, operation) do
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
+          {:ok, any} | {:error, map()}
+  def request(%Device{} = device, auth \\ :xml_auth, operation) do
     content = generate_content(operation)
     soap_action = operation.soap_action()
 
-    (uri <> @endpoint)
+    (device.address <> device.device_service_path)
     |> Onvif.API.client(auth)
     |> Tesla.request(
       method: :post,

--- a/lib/devices/get_device_information.ex
+++ b/lib/devices/get_device_information.ex
@@ -2,9 +2,13 @@ defmodule Onvif.Devices.GetDeviceInformation do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetDeviceInformation"
 
-  def request(uri, auth \\ :xml_auth), do: Onvif.Devices.request(uri, auth, __MODULE__)
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
+          {:ok, any} | {:error, map()}
+  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetDeviceInformation")])

--- a/lib/devices/get_hostname.ex
+++ b/lib/devices/get_hostname.ex
@@ -2,9 +2,13 @@ defmodule Onvif.Devices.GetHostname do
   # import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetHostname"
 
-  def request(uri, auth \\ :xml_auth), do: Onvif.Devices.request(uri, auth, __MODULE__)
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
+          {:ok, any} | {:error, map()}
+  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetHostname")])

--- a/lib/devices/get_scopes.ex
+++ b/lib/devices/get_scopes.ex
@@ -2,9 +2,13 @@ defmodule Onvif.Devices.GetScopes do
   # import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetScopes"
 
-  def request(uri, auth \\ :xml_auth), do: Onvif.Devices.request(uri, auth, __MODULE__)
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
+          {:ok, any} | {:error, map()}
+  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetScopes")])

--- a/lib/devices/get_service_capabilities.ex
+++ b/lib/devices/get_service_capabilities.ex
@@ -1,10 +1,13 @@
 defmodule Onvif.Devices.GetServiceCapabilities do
   # import SweetXml
   import XmlBuilder
+  alias Onvif.Device
 
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetServiceCapabilities"
 
-  def request(uri, auth \\ :no_auth), do: Onvif.Devices.request(uri, auth, __MODULE__)
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
+          {:ok, any} | {:error, map()}
+  def request(device, auth \\ :no_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetServiceCapabilities")])

--- a/lib/devices/get_services.ex
+++ b/lib/devices/get_services.ex
@@ -2,9 +2,13 @@ defmodule Onvif.Devices.GetServices do
   # import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetServices"
 
-  def request(uri, auth \\ :xml_auth), do: Onvif.Devices.request(uri, auth, __MODULE__)
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
+          {:ok, any} | {:error, map()}
+  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetServices", [element(:"tds:IncludeCapability", "true")])])

--- a/lib/devices/get_system_date_and_time.ex
+++ b/lib/devices/get_system_date_and_time.ex
@@ -2,9 +2,12 @@ defmodule Onvif.Devices.GetSystemDateAndTime do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetSystemDateAndTime"
 
-  def request(uri), do: Onvif.Devices.request(uri, :no_auth, __MODULE__)
+  @spec request(Device.t()) :: {:ok, any} | {:error, map()}
+  def request(device), do: Onvif.Devices.request(device, :no_auth, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetSystemDateAndTime")])


### PR DESCRIPTION
- To be consistent across device and media service request usage, we are [transitioning to using device struct](https://github.com/hammeraj/onvif/pull/18#discussion_r1323417737) to construct the respective device service path.
- This PR addresses this change only for the device service requests