### PR TITLE
Use device struct in media service API

### DIFF
--- a/lib/media/ver10/get_profile.ex
+++ b/lib/media/ver10/get_profile.ex
@@ -2,8 +2,12 @@ defmodule Onvif.Media.Ver10.GetProfile do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetProfiles"
 
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
+          {:ok, any} | {:error, map()}
   def request(uri, auth \\ :xml_auth, args),
     do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
 

--- a/lib/media/ver10/get_profile.ex
+++ b/lib/media/ver10/get_profile.ex
@@ -8,8 +8,8 @@ defmodule Onvif.Media.Ver10.GetProfile do
 
   @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
           {:ok, any} | {:error, map()}
-  def request(uri, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
+  def request(device, auth \\ :xml_auth, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
 
   def request_body(profile_token) do
     element(:"s:Body", [element(:"trt:GetProfile", [element(:"trt:ProfileToken", profile_token)])])

--- a/lib/media/ver10/get_profiles.ex
+++ b/lib/media/ver10/get_profiles.ex
@@ -8,8 +8,8 @@ defmodule Onvif.Media.Ver10.GetProfiles do
 
   @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
           {:ok, any} | {:error, map()}
-  def request(uri, auth \\ :no_auth),
-    do: Onvif.Media.Ver10.Media.request(uri, [], auth, __MODULE__)
+  def request(device, auth \\ :no_auth),
+    do: Onvif.Media.Ver10.Media.request(device, [], auth, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"trt:GetProfiles")])

--- a/lib/media/ver10/get_profiles.ex
+++ b/lib/media/ver10/get_profiles.ex
@@ -2,8 +2,12 @@ defmodule Onvif.Media.Ver10.GetProfiles do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetProfiles"
 
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
+          {:ok, any} | {:error, map()}
   def request(uri, auth \\ :no_auth),
     do: Onvif.Media.Ver10.Media.request(uri, [], auth, __MODULE__)
 

--- a/lib/media/ver10/get_stream_uri.ex
+++ b/lib/media/ver10/get_stream_uri.ex
@@ -2,8 +2,12 @@ defmodule Onvif.Media.Ver10.GetStreamUri do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetStreamUri"
 
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
+          {:ok, any} | {:error, map()}
   def request(uri, auth \\ :xml_auth, args),
     do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
 

--- a/lib/media/ver10/get_stream_uri.ex
+++ b/lib/media/ver10/get_stream_uri.ex
@@ -8,8 +8,8 @@ defmodule Onvif.Media.Ver10.GetStreamUri do
 
   @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
           {:ok, any} | {:error, map()}
-  def request(uri, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
+  def request(device, auth \\ :xml_auth, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
 
   def request_body(profile_token, stream_type \\ "RTP-Unicast", protocol \\ "RTSP") do
     element(:"s:Body", [

--- a/lib/media/ver10/get_video_encoder_configuration.ex
+++ b/lib/media/ver10/get_video_encoder_configuration.ex
@@ -2,13 +2,16 @@ defmodule Onvif.Media.Ver10.GetVideoEncoderConfiguration do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
   alias Onvif.Media.Ver10.Profile.VideoEncoderConfiguration
 
   @spec soap_action :: String.t()
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetVideoEncoderConfiguration"
 
-  def request(uri, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
+          {:ok, any} | {:error, map()}
+  def request(device, auth \\ :xml_auth, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
 
   def request_body(configuration_token) do
     element(:"s:Body", [

--- a/lib/media/ver10/media.ex
+++ b/lib/media/ver10/media.ex
@@ -6,19 +6,19 @@ defmodule Onvif.Media.Ver10.Media do
   """
   require Logger
 
-  @endpoint "/onvif/media_service"
+  alias Onvif.Device
 
   @namespaces [
     "xmlns:trt": "http://www.onvif.org/ver10/media/wsdl"
   ]
 
-  @spec request(String.t(), list, :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
-          {:ok, any} | {:error, String.t()}
-  def request(uri, args \\ [], auth \\ :xml_auth, operation) do
+  @spec request(Device.t(), list, :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
+          {:ok, any} | {:error, map()}
+  def request(%Device{} = device, args \\ [], auth \\ :xml_auth, operation) do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
-    (uri <> @endpoint)
+    (device.address <> device.media_service_path)
     |> Onvif.API.client(auth)
     |> Tesla.request(
       method: :post,

--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -1,12 +1,16 @@
 defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
-  alias Onvif.Media.Ver10.Profile.VideoEncoderConfiguration
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+  alias Onvif.Media.Ver10.Profile.VideoEncoderConfiguration
+
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/SetVideoEncoderConfiguration"
 
-  def request(uri, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(uri, args, auth, __MODULE__)
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
+          {:ok, any} | {:error, map()}
+  def request(device, auth \\ :xml_auth, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
 
   def request_body(%VideoEncoderConfiguration{} = video_encoder_config) do
     element(:"s:Body", [

--- a/lib/media/ver20/get_profiles.ex
+++ b/lib/media/ver20/get_profiles.ex
@@ -8,8 +8,8 @@ defmodule Onvif.Media.Ver20.GetProfiles do
 
   @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
           {:ok, any} | {:error, map()}
-  def request(uri, auth \\ :xml_auth, args \\ []),
-    do: Onvif.Media.Ver20.Media.request(uri, args, auth, __MODULE__)
+  def request(device, auth \\ :xml_auth, args \\ []),
+    do: Onvif.Media.Ver20.Media.request(device, args, auth, __MODULE__)
 
   def request_body(profile_token) do
     element(:"s:Body", [

--- a/lib/media/ver20/get_profiles.ex
+++ b/lib/media/ver20/get_profiles.ex
@@ -2,8 +2,12 @@ defmodule Onvif.Media.Ver20.GetProfiles do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver20/media/wsdl/GetProfiles"
 
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
+          {:ok, any} | {:error, map()}
   def request(uri, auth \\ :xml_auth, args \\ []),
     do: Onvif.Media.Ver20.Media.request(uri, args, auth, __MODULE__)
 

--- a/lib/media/ver20/get_stream_uri.ex
+++ b/lib/media/ver20/get_stream_uri.ex
@@ -8,8 +8,8 @@ defmodule Onvif.Media.Ver20.GetStreamUri do
 
   @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
           {:ok, any} | {:error, map()}
-  def request(uri, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver20.Media.request(uri, args, auth, __MODULE__)
+  def request(device, auth \\ :xml_auth, args),
+    do: Onvif.Media.Ver20.Media.request(device, args, auth, __MODULE__)
 
   def request_body(profile_token, protocol \\ "RTSP") do
     element(:"s:Body", [

--- a/lib/media/ver20/get_stream_uri.ex
+++ b/lib/media/ver20/get_stream_uri.ex
@@ -2,8 +2,12 @@ defmodule Onvif.Media.Ver20.GetStreamUri do
   import SweetXml
   import XmlBuilder
 
+  alias Onvif.Device
+
   def soap_action, do: "http://www.onvif.org/ver20/media/wsdl/GetStreamUri"
 
+  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
+          {:ok, any} | {:error, map()}
   def request(uri, auth \\ :xml_auth, args),
     do: Onvif.Media.Ver20.Media.request(uri, args, auth, __MODULE__)
 

--- a/lib/media/ver20/media.ex
+++ b/lib/media/ver20/media.ex
@@ -6,6 +6,8 @@ defmodule Onvif.Media.Ver20.Media do
   """
   require Logger
 
+  alias Onvif.Device
+
   @endpoint "/onvif/media"
 
   @namespaces [
@@ -13,11 +15,13 @@ defmodule Onvif.Media.Ver20.Media do
     "xmlns:tt": "http://www.onvif.org/ver10/schema"
   ]
 
-  def request(uri, args \\ [], auth \\ :xml_auth, operation) do
+  @spec request(Device.t(), list, :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
+          {:ok, any} | {:error, map()}
+  def request(%Device{} = device, args \\ [], auth \\ :xml_auth, operation) do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
-    (uri <> @endpoint)
+    (device.address <> device.media_service_path)
     |> Onvif.API.client(auth)
     |> Tesla.request(
       method: :post,


### PR DESCRIPTION
- To be consistent across device and media service request usage, we are [transitioning to using device struct](https://github.com/hammeraj/onvif/pull/18#discussion_r1323417737) to construct the respective device service path.
- This PR addresses this change for the media ver10 and ver20 service requests