### PR TITLE
Use the auth type from device struct

### DIFF
--- a/lib/device.ex
+++ b/lib/device.ex
@@ -13,7 +13,7 @@ defmodule Onvif.Device do
                 :hardware_id,
                 :ntp,
                 :media_service_path,
-                auth_type: :no_auth,
+                auth_type: :xml_auth,
                 time_diff_from_system_secs: 0,
                 port: 80,
                 supports_media2?: false,

--- a/lib/device.ex
+++ b/lib/device.ex
@@ -5,7 +5,6 @@ defmodule Onvif.Device do
 
   defstruct @enforce_keys ++
               [
-                :auth_type,
                 :scopes,
                 :manufacturer,
                 :model,
@@ -14,6 +13,7 @@ defmodule Onvif.Device do
                 :hardware_id,
                 :ntp,
                 :media_service_path,
+                auth_type: :no_auth,
                 time_diff_from_system_secs: 0,
                 port: 80,
                 supports_media2?: false,

--- a/lib/devices/devices.ex
+++ b/lib/devices/devices.ex
@@ -11,14 +11,13 @@ defmodule Onvif.Devices do
     "xmlns:tds": "http://www.onvif.org/ver10/device/wsdl"
   ]
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
-          {:ok, any} | {:error, map()}
-  def request(%Device{} = device, auth \\ :xml_auth, operation) do
+  @spec request(Device.t(), module()) :: {:ok, any} | {:error, map()}
+  def request(%Device{} = device, operation) do
     content = generate_content(operation)
     soap_action = operation.soap_action()
 
     (device.address <> device.device_service_path)
-    |> Onvif.API.client(auth)
+    |> Onvif.API.client(device.auth_type)
     |> Tesla.request(
       method: :post,
       headers: [{"Content-Type", "application/soap+xml"}, {"SOAPAction", soap_action}],

--- a/lib/devices/get_device_information.ex
+++ b/lib/devices/get_device_information.ex
@@ -6,9 +6,8 @@ defmodule Onvif.Devices.GetDeviceInformation do
 
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetDeviceInformation"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
+  @spec request(Device.t()) :: {:ok, any} | {:error, map()}
+  def request(device), do: Onvif.Devices.request(device, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetDeviceInformation")])

--- a/lib/devices/get_hostname.ex
+++ b/lib/devices/get_hostname.ex
@@ -6,9 +6,8 @@ defmodule Onvif.Devices.GetHostname do
 
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetHostname"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
+  @spec request(Device.t()) :: {:ok, any} | {:error, map()}
+  def request(device), do: Onvif.Devices.request(device, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetHostname")])

--- a/lib/devices/get_scopes.ex
+++ b/lib/devices/get_scopes.ex
@@ -6,9 +6,8 @@ defmodule Onvif.Devices.GetScopes do
 
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetScopes"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
+  @spec request(Device.t()) :: {:ok, any} | {:error, map()}
+  def request(device), do: Onvif.Devices.request(device, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetScopes")])

--- a/lib/devices/get_service_capabilities.ex
+++ b/lib/devices/get_service_capabilities.ex
@@ -5,9 +5,8 @@ defmodule Onvif.Devices.GetServiceCapabilities do
 
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetServiceCapabilities"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :no_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
+  @spec request(Device.t()) :: {:ok, any} | {:error, map()}
+  def request(device), do: Onvif.Devices.request(device, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetServiceCapabilities")])

--- a/lib/devices/get_services.ex
+++ b/lib/devices/get_services.ex
@@ -6,9 +6,8 @@ defmodule Onvif.Devices.GetServices do
 
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetServices"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth), do: Onvif.Devices.request(device, auth, __MODULE__)
+  @spec request(Device.t()) :: {:ok, any} | {:error, map()}
+  def request(device), do: Onvif.Devices.request(device, __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetServices", [element(:"tds:IncludeCapability", "true")])])

--- a/lib/devices/get_system_date_and_time.ex
+++ b/lib/devices/get_system_date_and_time.ex
@@ -7,7 +7,11 @@ defmodule Onvif.Devices.GetSystemDateAndTime do
   def soap_action, do: "http://www.onvif.org/ver10/device/wsdl/GetSystemDateAndTime"
 
   @spec request(Device.t()) :: {:ok, any} | {:error, map()}
-  def request(device), do: Onvif.Devices.request(device, :no_auth, __MODULE__)
+  def request(device) do
+    # Enforce no_auth for GetSystemDateAndTime to comply with ONVIF
+    updated_device = %{device | auth_type: :no_auth}
+    Onvif.Devices.request(updated_device, __MODULE__)
+  end
 
   def request_body do
     element(:"s:Body", [element(:"tds:GetSystemDateAndTime")])

--- a/lib/media/ver10/get_profile.ex
+++ b/lib/media/ver10/get_profile.ex
@@ -6,10 +6,9 @@ defmodule Onvif.Media.Ver10.GetProfile do
 
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetProfiles"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
+  @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
+  def request(device, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
   def request_body(profile_token) do
     element(:"s:Body", [element(:"trt:GetProfile", [element(:"trt:ProfileToken", profile_token)])])

--- a/lib/media/ver10/get_profiles.ex
+++ b/lib/media/ver10/get_profiles.ex
@@ -6,10 +6,9 @@ defmodule Onvif.Media.Ver10.GetProfiles do
 
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetProfiles"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :no_auth),
-    do: Onvif.Media.Ver10.Media.request(device, [], auth, __MODULE__)
+  @spec request(Device.t()) :: {:ok, any} | {:error, map()}
+  def request(device),
+    do: Onvif.Media.Ver10.Media.request(device, [], __MODULE__)
 
   def request_body do
     element(:"s:Body", [element(:"trt:GetProfiles")])

--- a/lib/media/ver10/get_stream_uri.ex
+++ b/lib/media/ver10/get_stream_uri.ex
@@ -6,10 +6,9 @@ defmodule Onvif.Media.Ver10.GetStreamUri do
 
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetStreamUri"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
+  @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
+  def request(device, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
   def request_body(profile_token, stream_type \\ "RTP-Unicast", protocol \\ "RTSP") do
     element(:"s:Body", [

--- a/lib/media/ver10/get_video_encoder_configuration.ex
+++ b/lib/media/ver10/get_video_encoder_configuration.ex
@@ -8,10 +8,9 @@ defmodule Onvif.Media.Ver10.GetVideoEncoderConfiguration do
   @spec soap_action :: String.t()
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetVideoEncoderConfiguration"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
+  @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
+  def request(device, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
   def request_body(configuration_token) do
     element(:"s:Body", [

--- a/lib/media/ver10/media.ex
+++ b/lib/media/ver10/media.ex
@@ -12,14 +12,13 @@ defmodule Onvif.Media.Ver10.Media do
     "xmlns:trt": "http://www.onvif.org/ver10/media/wsdl"
   ]
 
-  @spec request(Device.t(), list, :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
-          {:ok, any} | {:error, map()}
-  def request(%Device{} = device, args \\ [], auth \\ :xml_auth, operation) do
+  @spec request(Device.t(), list, module()) :: {:ok, any} | {:error, map()}
+  def request(%Device{} = device, args \\ [], operation) do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
     (device.address <> device.media_service_path)
-    |> Onvif.API.client(auth)
+    |> Onvif.API.client(device.auth_type)
     |> Tesla.request(
       method: :post,
       headers: [{"Content-Type", "application/soap+xml"}, {"SOAPAction", soap_action}],

--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -7,10 +7,9 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
 
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/SetVideoEncoderConfiguration"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver10.Media.request(device, args, auth, __MODULE__)
+  @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
+  def request(device, args),
+    do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
   def request_body(%VideoEncoderConfiguration{} = video_encoder_config) do
     element(:"s:Body", [

--- a/lib/media/ver20/get_profiles.ex
+++ b/lib/media/ver20/get_profiles.ex
@@ -6,10 +6,9 @@ defmodule Onvif.Media.Ver20.GetProfiles do
 
   def soap_action, do: "http://www.onvif.org/ver20/media/wsdl/GetProfiles"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth, args \\ []),
-    do: Onvif.Media.Ver20.Media.request(device, args, auth, __MODULE__)
+  @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
+  def request(device, args \\ []),
+    do: Onvif.Media.Ver20.Media.request(device, args, __MODULE__)
 
   def request_body(profile_token) do
     element(:"s:Body", [

--- a/lib/media/ver20/get_stream_uri.ex
+++ b/lib/media/ver20/get_stream_uri.ex
@@ -6,10 +6,9 @@ defmodule Onvif.Media.Ver20.GetStreamUri do
 
   def soap_action, do: "http://www.onvif.org/ver20/media/wsdl/GetStreamUri"
 
-  @spec request(Device.t(), :basic_auth | :digest_auth | :no_auth | :xml_auth, list) ::
-          {:ok, any} | {:error, map()}
-  def request(device, auth \\ :xml_auth, args),
-    do: Onvif.Media.Ver20.Media.request(device, args, auth, __MODULE__)
+  @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
+  def request(device, args),
+    do: Onvif.Media.Ver20.Media.request(device, args, __MODULE__)
 
   def request_body(profile_token, protocol \\ "RTSP") do
     element(:"s:Body", [

--- a/lib/media/ver20/media.ex
+++ b/lib/media/ver20/media.ex
@@ -8,21 +8,18 @@ defmodule Onvif.Media.Ver20.Media do
 
   alias Onvif.Device
 
-  @endpoint "/onvif/media"
-
   @namespaces [
     "xmlns:tr2": "http://www.onvif.org/ver20/media/wsdl",
     "xmlns:tt": "http://www.onvif.org/ver10/schema"
   ]
 
-  @spec request(Device.t(), list, :basic_auth | :digest_auth | :no_auth | :xml_auth, module()) ::
-          {:ok, any} | {:error, map()}
-  def request(%Device{} = device, args \\ [], auth \\ :xml_auth, operation) do
+  @spec request(Device.t(), list, module()) :: {:ok, any} | {:error, map()}
+  def request(%Device{} = device, args \\ [], operation) do
     content = generate_content(operation, args)
     soap_action = operation.soap_action()
 
     (device.address <> device.media_service_path)
-    |> Onvif.API.client(auth)
+    |> Onvif.API.client(device.auth_type)
     |> Tesla.request(
       method: :post,
       headers: [{"Content-Type", "application/soap+xml"}, {"SOAPAction", soap_action}],


### PR DESCRIPTION
- Removed the auth param from the media and device request calls since we can reuse the `auth_type` from the device struct.