### PR TITLE
Fix media ver20 GerProfiles

### DIFF
--- a/lib/media/ver20/get_profiles.ex
+++ b/lib/media/ver20/get_profiles.ex
@@ -20,7 +20,7 @@ defmodule Onvif.Media.Ver20.GetProfiles do
   end
 
   def request_body do
-    element(:"s:Body", [element(:"trt:GetProfiles", [element(:"tr2:Type", "All")])])
+    element(:"s:Body", [element(:"tr2:GetProfiles", [element(:"tr2:Type", "All")])])
   end
 
   def response(xml_response_body) do

--- a/lib/media/ver20/profile/video_encoder.ex
+++ b/lib/media/ver20/profile/video_encoder.ex
@@ -43,7 +43,7 @@ defmodule Onvif.Media.Ver20.Profile.VideoEncoder do
       doc,
       reference_token: ~x"./@token"s,
       profile: ~x"./@Profile"s,
-      gov_length: ~x"./@GovLength"i,
+      gov_length: ~x"./@GovLength"io,
       name: ~x"./tt:Name/text()"s,
       use_count: ~x"./tt:UseCount/text()"i,
       guaranteed_frame_rate: ~x"./tt:GuaranteedFrameRate/text()"s,


### PR DESCRIPTION
- Changed the namespace to `tr2` since we are using `tr2` element and not `trt` in media ver20 calls. 
- GovLength seems to be optional for some image-specific profiles on the axis camera which I tested. So made it optional to avoid sweetxml from crashing.