### PR TITLE
Log invalid changesets from map transformations 

### DIFF
--- a/lib/device.ex
+++ b/lib/device.ex
@@ -36,7 +36,9 @@ defmodule Onvif.Device do
   authentication required endpoint and swap out auth_type for the one that works.
   """
   @spec new(String.t(), String.t(), String.t()) :: __MODULE__.t()
-  def new(address, username, password), do: %__MODULE__{address: address, username: username, password: password}
+  def new(address, username, password) do
+    %__MODULE__{address: address, username: username, password: password}
+  end
 
   @doc """
   Returns a `Device.t()` struct prepopulated with data required to make an Onvif API

--- a/lib/devices/service.ex
+++ b/lib/devices/service.ex
@@ -36,10 +36,6 @@ defmodule Onvif.Device.Service do
     %__MODULE__{}
     |> changeset(parsed)
     |> apply_action(:validate)
-    |> case do
-      {:ok, data} -> data
-      {:error, _changeset} -> Logger.error("Error in validating device service changeset")
-    end
   end
 
   def changeset(module, attrs) do

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -64,7 +64,8 @@ defmodule Onvif.Discovery do
     an onvif scope - `"onvif://www.onvif.org/scope_name/scope_value"`, not guaranteed to be present
     a list of onvif scopes - matches the first one to succeed linking to a probe
   """
-  @spec probe_by(Keyword.t() | String.t() | list(String.t())) :: {:error, :invalid_filter | :invalid_mac | :not_found} | {:ok, Probe.t()}
+  @spec probe_by(Keyword.t() | String.t() | list(String.t())) ::
+          {:error, :invalid_filter | :invalid_mac | :not_found} | {:ok, Probe.t()}
   def probe_by(serial: serial) when is_binary(serial) do
     probe_by(@onvif_scope_prefix <> "serial/" <> serial)
   end
@@ -81,7 +82,10 @@ defmodule Onvif.Discovery do
   def probe_by(mac_address: mac_address) when is_binary(mac_address) do
     with {:ok, mac_with_colons} <- Onvif.MacAddress.mac_with_colons(mac_address),
          {:ok, mac_just_digits} <- Onvif.MacAddress.mac_just_digits(mac_address) do
-      probe_by([@onvif_scope_prefix <> "macaddr/" <> mac_just_digits, @onvif_scope_prefix <> "MAC/" <> mac_with_colons])
+      probe_by([
+        @onvif_scope_prefix <> "macaddr/" <> mac_just_digits,
+        @onvif_scope_prefix <> "MAC/" <> mac_with_colons
+      ])
     end
   end
 

--- a/lib/mac_address.ex
+++ b/lib/mac_address.ex
@@ -12,7 +12,12 @@ defmodule Onvif.MacAddress do
         {:ok, mac_address |> String.replace("-", ":") |> String.downcase()}
 
       Regex.match?(@mac_regex, mac_address) ->
-        {:ok, mac_address |> String.split("", trim: true) |> Enum.chunk_every(2) |> Enum.join(":") |> String.downcase()}
+        {:ok,
+         mac_address
+         |> String.split("", trim: true)
+         |> Enum.chunk_every(2)
+         |> Enum.join(":")
+         |> String.downcase()}
 
       true ->
         {:error, :invalid_mac}

--- a/lib/media/ver10/get_profiles.ex
+++ b/lib/media/ver10/get_profiles.ex
@@ -2,6 +2,8 @@ defmodule Onvif.Media.Ver10.GetProfiles do
   import SweetXml
   import XmlBuilder
 
+  require Logger
+
   alias Onvif.Device
 
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetProfiles"
@@ -14,16 +16,33 @@ defmodule Onvif.Media.Ver10.GetProfiles do
     element(:"s:Body", [element(:"trt:GetProfiles")])
   end
 
+  @doc """
+  Parses the device response into a `{:ok, profiles}` tuple where `profiles`
+  is a list, discarding the invalid transformations from map into a
+  Onvif.Media.Ver10.Profile.t().
+  """
   def response(xml_response_body) do
-    xml_response_body
-    |> parse(namespace_conformant: true, quiet: true)
-    |> xpath(
-      ~x"//s:Envelope/s:Body/trt:GetProfilesResponse/trt:Profiles"el
-      |> add_namespace("s", "http://www.w3.org/2003/05/soap-envelope")
-      |> add_namespace("trt", "http://www.onvif.org/ver10/media/wsdl")
-      |> add_namespace("tt", "http://www.onvif.org/ver10/schema")
-    )
-    |> Enum.map(&Onvif.Media.Ver10.Profile.parse/1)
-    |> Enum.map(&Onvif.Media.Ver10.Profile.to_struct/1)
+    response =
+      xml_response_body
+      |> parse(namespace_conformant: true, quiet: true)
+      |> xpath(
+        ~x"//s:Envelope/s:Body/trt:GetProfilesResponse/trt:Profiles"el
+        |> add_namespace("s", "http://www.w3.org/2003/05/soap-envelope")
+        |> add_namespace("trt", "http://www.onvif.org/ver10/media/wsdl")
+        |> add_namespace("tt", "http://www.onvif.org/ver10/schema")
+      )
+      |> Enum.map(&Onvif.Media.Ver10.Profile.parse/1)
+      |> Enum.reduce([], fn raw_profile, acc ->
+        case Onvif.Media.Ver10.Profile.to_struct(raw_profile) do
+          {:ok, profile} ->
+            [profile | acc]
+
+          {:error, changeset} ->
+            Logger.error("Discarding invalid profile: #{inspect(changeset)}")
+            acc
+        end
+      end)
+
+    {:ok, response}
   end
 end

--- a/lib/media/ver20/get_profiles.ex
+++ b/lib/media/ver20/get_profiles.ex
@@ -2,6 +2,8 @@ defmodule Onvif.Media.Ver20.GetProfiles do
   import SweetXml
   import XmlBuilder
 
+  require Logger
+
   alias Onvif.Device
 
   def soap_action, do: "http://www.onvif.org/ver20/media/wsdl/GetProfiles"
@@ -23,16 +25,33 @@ defmodule Onvif.Media.Ver20.GetProfiles do
     element(:"s:Body", [element(:"tr2:GetProfiles", [element(:"tr2:Type", "All")])])
   end
 
+  @doc """
+  Parses the device response into a `{:ok, profiles}` tuple where `profiles`
+  is a list, discarding the invalid transformations from map into a
+  Onvif.Media.Ver20.Profile.t().
+  """
   def response(xml_response_body) do
-    xml_response_body
-    |> parse(namespace_conformant: true, quiet: true)
-    |> xpath(
-      ~x"//s:Envelope/s:Body/tr2:GetProfilesResponse/tr2:Profiles"el
-      |> add_namespace("s", "http://www.w3.org/2003/05/soap-envelope")
-      |> add_namespace("tr2", "http://www.onvif.org/ver20/media/wsdl")
-      |> add_namespace("tt", "http://www.onvif.org/ver10/schema")
-    )
-    |> Enum.map(&Onvif.Media.Ver20.Profile.parse/1)
-    |> Enum.map(&Onvif.Media.Ver20.Profile.to_struct/1)
+    response =
+      xml_response_body
+      |> parse(namespace_conformant: true, quiet: true)
+      |> xpath(
+        ~x"//s:Envelope/s:Body/tr2:GetProfilesResponse/tr2:Profiles"el
+        |> add_namespace("s", "http://www.w3.org/2003/05/soap-envelope")
+        |> add_namespace("tr2", "http://www.onvif.org/ver20/media/wsdl")
+        |> add_namespace("tt", "http://www.onvif.org/ver10/schema")
+      )
+      |> Enum.map(&Onvif.Media.Ver20.Profile.parse/1)
+      |> Enum.reduce([], fn raw_profile, acc ->
+        case Onvif.Media.Ver20.Profile.to_struct(raw_profile) do
+          {:ok, profile} ->
+            [profile | acc]
+
+          {:error, changeset} ->
+            Logger.error("Discarding invalid profile: #{inspect(changeset)}")
+            acc
+        end
+      end)
+
+    {:ok, response}
   end
 end


### PR DESCRIPTION
Related to https://github.com/hammeraj/onvif/pull/17#discussion_r1320051608 and candidate to superseed https://github.com/hammeraj/onvif/pull/24.

* log invalid changeset from map transformations (Service and Profile)
  when requesting a list of services or profiles
* filter out the invalid changesets from the final response