### PR TITLE
Add missing elements in SetVideoEncoderConfiguration

### DIFF
--- a/lib/media/ver10/profile/multicast_configuration.ex
+++ b/lib/media/ver10/profile/multicast_configuration.ex
@@ -15,7 +15,7 @@ defmodule Onvif.Media.Ver10.Profile.MulticastConfiguration do
 
     embeds_one :ip_address, IpAddress, primary_key: false, on_replace: :update do
       field(:type, Ecto.Enum, values: [ipv4: "IPv4", ipv6: "IPv6"])
-      field(:ipv4_address, :string, default: "0.0.0.0")
+      field(:ipv4_address, :string)
       field(:ipv6_address, :string)
     end
   end

--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -15,6 +15,8 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
     element(:"s:Body", [
       element(:"trt:SetVideoEncoderConfiguration", [
         element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
+          element(:"tt:Name", video_encoder_config.name),
+          element(:"tt:UseCount", video_encoder_config.use_count),
           element(
             :"tt:Encoding",
             Keyword.fetch!(
@@ -35,8 +37,10 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
             element(:"tt:EncodingInterval", video_encoder_config.rate_control.encoding_interval),
             element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
           ]),
-          multicast_element(video_encoder_config.multicast_configuration)
-        ])
+          multicast_element(video_encoder_config.multicast_configuration),
+          element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
+        ]),
+        element(:"trt:ForcePersistence", true)
       ])
     ])
   end
@@ -84,6 +88,7 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
       ~x"//s:Envelope/s:Body/trt:SetVideoEncoderConfigurationResponse/text()"s
       |> add_namespace("s", "http://www.w3.org/2003/05/soap-envelope")
       |> add_namespace("trt", "http://www.onvif.org/ver10/media/wsdl")
+      |> add_namespace("tt", "http://www.onvif.org/ver10/schema")
     )
   end
 end


### PR DESCRIPTION
- Added name, use count, force persistence, and session timeout. Without these elements, the Axis device responds with a 400 status code.
- Also reverted default value for ipv4 address since "0.0.0.0" doesn't work for Uniview devices. Axis doesn't support nil as ipv4address but with the device, I tested it sends default as "0.0.0.0" when we get the video encoder configuration using `GetProfiles` or `GetVideoEncoderConfiguration` so it should use the default as "0.0.0.0" without us enforcing.