### PR TITLE
Add missing services key in device struct

### DIFF
--- a/lib/device.ex
+++ b/lib/device.ex
@@ -17,6 +17,7 @@ defmodule Onvif.Device do
                 :ntp,
                 :media_ver10_service_path,
                 :media_ver20_service_path,
+                :services,
                 auth_type: :xml_auth,
                 time_diff_from_system_secs: 0,
                 port: 80,


### PR DESCRIPTION
We are using it [here](https://github.com/hammeraj/onvif/blob/main/lib/device.ex#L204) but haven't added it in the struct.