### PR TITLE
Add support for GetVideoEncoderConfigurationOptions in media ver10

### DIFF
--- a/lib/media/ver10/get_video_encoder_configuration_options.ex
+++ b/lib/media/ver10/get_video_encoder_configuration_options.ex
@@ -1,0 +1,65 @@
+defmodule Onvif.Media.Ver10.GetVideoEncoderConfigurationOptions do
+  import SweetXml
+  import XmlBuilder
+
+  require Logger
+
+  alias Onvif.Device
+  alias Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption
+
+  @spec soap_action :: String.t()
+  def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetVideoEncoderConfigurationOptions"
+
+  @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
+  def request(device, args \\ []),
+    do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
+
+  def request_body() do
+    element(:"s:Body", [
+      element(:"trt:GetVideoEncoderConfigurationOptions")
+    ])
+  end
+
+  def request_body(configuration_token) do
+    element(:"s:Body", [
+      element(:"trt:GetVideoEncoderConfigurationOptions", [
+        element(:"trt:ConfigurationToken", configuration_token)
+      ])
+    ])
+  end
+
+  def request_body(configuration_token, profile_token) do
+    element(:"s:Body", [
+      element(:"trt:GetVideoEncoderConfigurationOptions", [
+        element(:"trt:ConfigurationToken", configuration_token),
+        element(:"trt:ProfileToken", profile_token)
+      ])
+    ])
+  end
+
+  @spec response(any) :: {:error, Ecto.Changeset.t()} | {:ok, struct()}
+  def response(xml_response_body) do
+    response =
+      xml_response_body
+      |> parse(namespace_conformant: true, quiet: true)
+      |> xpath(
+        ~x"//s:Envelope/s:Body/trt:GetVideoEncoderConfigurationOptionsResponse/trt:Options"el
+        |> add_namespace("s", "http://www.w3.org/2003/05/soap-envelope")
+        |> add_namespace("trt", "http://www.onvif.org/ver10/media/wsdl")
+        |> add_namespace("tt", "http://www.onvif.org/ver10/schema")
+      )
+      |> Enum.map(&VideoEncoderConfigurationOption.parse/1)
+      |> Enum.reduce([], fn raw_config, acc ->
+        case VideoEncoderConfigurationOption.to_struct(raw_config) do
+          {:ok, config} ->
+            [config | acc]
+
+          {:error, changeset} ->
+            Logger.error("Discarding invalid audio config: #{inspect(changeset)}")
+            acc
+        end
+      end)
+
+    {:ok, response}
+  end
+end

--- a/lib/media/ver10/profile/video_encoder_configuration_option.ex
+++ b/lib/media/ver10/profile/video_encoder_configuration_option.ex
@@ -1,0 +1,388 @@
+defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption do
+  @moduledoc """
+  Optional configuration of the Audio encoder.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  import SweetXml
+
+  @primary_key false
+  @derive Jason.Encoder
+  embedded_schema do
+    field(:guranteed_frame_rate_supported, :boolean)
+
+    embeds_one :quality_range, QualityRange, primary_key: false, on_replace: :update do
+      @derive Jason.Encoder
+      field(:min, :integer)
+      field(:max, :integer)
+    end
+
+    embeds_one :jpeg, JpegOptions, primary_key: false, on_replace: :update do
+      @derive Jason.Encoder
+      embeds_many :resolutions_available, ResolutionsAvailable,
+        primary_key: false,
+        on_replace: :delete do
+        @derive Jason.Encoder
+        field(:width, :integer)
+        field(:height, :integer)
+      end
+
+      embeds_one :frame_rate_range, FrameRateRange, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+
+      embeds_one :encoding_interval_range, EncodingIntervalRange,
+        primary_key: false,
+        on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+    end
+
+    embeds_one :mpeg4, Mpeg4Options, primary_key: false, on_replace: :update do
+      @derive Jason.Encoder
+      field(:mpeg4_profiles_supported, {:array, :string})
+
+      embeds_many :resolutions_available, ResolutionsAvailable,
+        primary_key: false,
+        on_replace: :delete do
+        @derive Jason.Encoder
+        field(:width, :integer)
+        field(:height, :integer)
+      end
+
+      embeds_one :gov_length_range, GovLengthRange, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+
+      embeds_one :frame_rate_range, FrameRateRange, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+
+      embeds_one :encoding_interval_range, EncodingIntervalRange,
+        primary_key: false,
+        on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+    end
+
+    embeds_one :h264, H264Options, primary_key: false, on_replace: :update do
+      @derive Jason.Encoder
+      field(:h264_profiles_supported, {:array, :string})
+
+      embeds_many :resolutions_available, ResolutionsAvailable,
+        primary_key: false,
+        on_replace: :delete do
+        @derive Jason.Encoder
+        field(:width, :integer)
+        field(:height, :integer)
+      end
+
+      embeds_one :gov_length_range, GovLengthRange, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+
+      embeds_one :frame_rate_range, FrameRateRange, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+
+      embeds_one :encoding_interval_range, EncodingIntervalRange,
+        primary_key: false,
+        on_replace: :update do
+        @derive Jason.Encoder
+        field(:min, :integer)
+        field(:max, :integer)
+      end
+    end
+
+    embeds_one :extension, Extension, primary_key: false, on_replace: :update do
+      embeds_one :jpeg, JpegOptions, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        embeds_many :resolutions_available, ResolutionsAvailable,
+          primary_key: false,
+          on_replace: :delete do
+          @derive Jason.Encoder
+          field(:width, :integer)
+          field(:height, :integer)
+        end
+
+        embeds_one :frame_rate_range, FrameRateRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :encoding_interval_range, EncodingIntervalRange,
+          primary_key: false,
+          on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :bitrate_range, BitrateRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+      end
+
+      embeds_one :mpeg4, Mpeg4Options, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        field(:mpeg4_profiles_supported, {:array, :string})
+
+        embeds_many :resolutions_available, ResolutionsAvailable,
+          primary_key: false,
+          on_replace: :delete do
+          @derive Jason.Encoder
+          field(:width, :integer)
+          field(:height, :integer)
+        end
+
+        embeds_one :gov_length_range, GovLengthRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :frame_rate_range, FrameRateRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :encoding_interval_range, EncodingIntervalRange,
+          primary_key: false,
+          on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :bitrate_range, BitrateRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+      end
+
+      embeds_one :h264, H264Options, primary_key: false, on_replace: :update do
+        @derive Jason.Encoder
+        field(:h264_profiles_supported, {:array, :string})
+
+        embeds_many :resolutions_available, ResolutionsAvailable1,
+          primary_key: false,
+          on_replace: :delete do
+          @derive Jason.Encoder
+          field(:width, :integer)
+          field(:height, :integer)
+        end
+
+        embeds_one :gov_length_range, GovLengthRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :frame_rate_range, FrameRateRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :encoding_interval_range, EncodingIntervalRange,
+          primary_key: false,
+          on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+
+        embeds_one :bitrate_range, BitrateRange, primary_key: false, on_replace: :update do
+          @derive Jason.Encoder
+          field(:min, :integer)
+          field(:max, :integer)
+        end
+      end
+    end
+  end
+
+  def changeset(module, attrs) do
+    module
+    |> cast(attrs, [:guranteed_frame_rate_supported])
+    |> cast_embed(:quality_range, with: &int_range_changeset/2)
+    |> cast_embed(:jpeg, with: &jpeg_changeset/2)
+    |> cast_embed(:mpeg4, with: &mpeg4_changeset/2)
+    |> cast_embed(:h264, with: &h264_changeset/2)
+    |> cast_embed(:extension, with: &extension_changeset/2)
+  end
+
+  def to_struct(parsed) do
+    %__MODULE__{}
+    |> changeset(parsed)
+    |> apply_action(:validate)
+  end
+
+  @spec to_json(%Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption{}) ::
+          {:error,
+           %{
+             :__exception__ => any,
+             :__struct__ => Jason.EncodeError | Protocol.UndefinedError,
+             optional(atom) => any
+           }}
+          | {:ok, binary}
+  def to_json(%__MODULE__{} = schema) do
+    Jason.encode(schema)
+  end
+
+  def parse(doc) do
+    xmap(
+      doc,
+      guranteed_frame_rate_supported: ~x"./tt:GuaranteedFrameRateSupported"s,
+      quality_range: ~x"./tt:QualityRange"e |> transform_by(&parse_int_range/1),
+      jpeg: ~x"./tt:JPEG"eo |> transform_by(&parse_jpeg/1),
+      mpeg4: ~x"./tt:MPEG4"eo |> transform_by(&parse_mpeg4/1),
+      h264: ~x"./tt:H264"eo |> transform_by(&parse_h264/1)
+    )
+  end
+
+  defp jpeg_changeset(module, attrs) do
+    module
+    |> cast(attrs, [])
+    |> cast_embed(:resolutions_available, with: &resolutions_available_changeset/2)
+    |> cast_embed(:frame_rate_range, with: &int_range_changeset/2)
+    |> cast_embed(:encoding_interval_range, with: &int_range_changeset/2)
+  end
+
+  defp mpeg4_changeset(module, attrs) do
+    module
+    |> cast(attrs, [:mpeg4_profiles_supported])
+    |> cast_embed(:resolutions_available, with: &resolutions_available_changeset/2)
+    |> cast_embed(:gov_length_range, with: &int_range_changeset/2)
+    |> cast_embed(:frame_rate_range, with: &int_range_changeset/2)
+    |> cast_embed(:encoding_interval_range, with: &int_range_changeset/2)
+  end
+
+  defp h264_changeset(module, attrs) do
+    module
+    |> cast(attrs, [:h264_profiles_supported])
+    |> cast_embed(:resolutions_available, with: &resolutions_available_changeset/2)
+    |> cast_embed(:gov_length_range, with: &int_range_changeset/2)
+    |> cast_embed(:frame_rate_range, with: &int_range_changeset/2)
+    |> cast_embed(:encoding_interval_range, with: &int_range_changeset/2)
+  end
+
+  defp extension_changeset(module, attrs) do
+    module
+    |> cast(attrs, [])
+    |> cast_embed(:jpeg, with: &jpeg_extension_changeset/2)
+    |> cast_embed(:mpeg4, with: &mpeg4_extension_changeset/2)
+    |> cast_embed(:h264, with: &h264_extension_changeset/2)
+  end
+
+  defp jpeg_extension_changeset(module, attrs) do
+    module
+    |> jpeg_changeset(attrs)
+    |> cast_embed(:bitrate_range, with: &int_range_changeset/2)
+  end
+
+  defp mpeg4_extension_changeset(module, attrs) do
+    module
+    |> mpeg4_changeset(attrs)
+    |> cast_embed(:bitrate_range, with: &int_range_changeset/2)
+  end
+
+  defp h264_extension_changeset(module, attrs) do
+    module
+    |> h264_changeset(attrs)
+    |> cast_embed(:bitrate_range, with: &int_range_changeset/2)
+  end
+
+  defp resolutions_available_changeset(module, attrs) do
+    cast(module, attrs, [:width, :height])
+  end
+
+  defp int_range_changeset(module, attrs) do
+    cast(module, attrs, [:min, :max])
+  end
+
+  defp parse_jpeg(nil) do
+    nil
+  end
+
+  defp parse_jpeg(doc) do
+    xmap(
+      doc,
+      resolutions_available:
+        ~x"./tt:ResolutionsAvailable"el |> transform_by(&parse_resolutions_available/1),
+      frame_rate_range: ~x"./tt:FrameRateRange"e |> transform_by(&parse_int_range/1),
+      encoding_interval_range: ~x"./tt:EncodingIntervalRange"e |> transform_by(&parse_int_range/1)
+    )
+  end
+
+  defp parse_mpeg4(nil) do
+    nil
+  end
+
+  defp parse_mpeg4(doc) do
+    xmap(
+      doc,
+      resolutions_available:
+        ~x"./tt:ResolutionsAvailable"el |> transform_by(&parse_resolutions_available/1),
+      gov_length_range: ~x"./tt:GovLengthRange"e |> transform_by(&parse_int_range/1),
+      frame_rate_range: ~x"./tt:FrameRateRange"e |> transform_by(&parse_int_range/1),
+      encoding_interval_range:
+        ~x"./tt:EncodingIntervalRange"e |> transform_by(&parse_int_range/1),
+      h264_profiles_supported: ~x"./tt:MPEG4ProfilesSupported/text()"sl
+    )
+  end
+
+  defp parse_h264(nil) do
+    nil
+  end
+
+  defp parse_h264(doc) do
+    xmap(
+      doc,
+      resolutions_available:
+        ~x"./tt:ResolutionsAvailable"el |> transform_by(&parse_resolutions_available/1),
+      gov_length_range: ~x"./tt:GovLengthRange"e |> transform_by(&parse_int_range/1),
+      frame_rate_range: ~x"./tt:FrameRateRange"e |> transform_by(&parse_int_range/1),
+      encoding_interval_range:
+        ~x"./tt:EncodingIntervalRange"e |> transform_by(&parse_int_range/1),
+      h264_profiles_supported: ~x"./tt:H264ProfilesSupported/text()"sl
+    )
+  end
+
+  defp parse_resolutions_available(resolutions) do
+    Enum.map(resolutions, fn resolution ->
+      xmap(
+        resolution,
+        width: ~x"./tt:Width/text()"i,
+        height: ~x"./tt:Height/text()"i
+      )
+    end)
+  end
+
+  defp parse_int_range(doc) do
+    xmap(
+      doc,
+      min: ~x"./tt:Min/text()"i,
+      max: ~x"./tt:Max/text()"i
+    )
+  end
+end

--- a/lib/media/ver10/profile/video_encoder_configuration_option.ex
+++ b/lib/media/ver10/profile/video_encoder_configuration_option.ex
@@ -1,6 +1,6 @@
 defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption do
   @moduledoc """
-  Optional configuration of the Audio encoder.
+  Optional configuration of the Video encoder.
   """
 
   use Ecto.Schema


### PR DESCRIPTION
- spec: https://www.onvif.org/ver10/media/wsdl/media.wsdl#op.GetVideoEncoderConfigurationOptions. 
- This is needed as a prerequisite step to validate the data which we use to update video encoder configuration using `SetVideoEncoderConfiguration`

![image](https://github.com/hammeraj/onvif/assets/9105503/d04fa027-232e-4500-b336-1591b2936e8f)

Test with uniview and axis.