### PR TITLE
Add support to update h264 and mpeg4 configs

### DIFF
--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -11,134 +11,38 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
   def request(device, args),
     do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
-  def request_body(%VideoEncoderConfiguration{} = video_encoder_config)
-      when not is_nil(video_encoder_config.h264_configuration) and
-             not is_nil(video_encoder_config.mpeg4_configuration) do
-    element(:"s:Body", [
-      element(:"trt:SetVideoEncoderConfiguration", [
-        element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
-          name_element(video_encoder_config),
-          use_count_element(video_encoder_config),
-          encoding_element(video_encoder_config),
-          quality_element(video_encoder_config),
-          resolution_element(video_encoder_config),
-          rate_control_element(video_encoder_config),
-          h264_element(video_encoder_config.h264_configuration),
-          mpeg4_element(video_encoder_config.mpeg4_configuration),
-          multicast_element(video_encoder_config.multicast_configuration),
-          session_timeout_element(video_encoder_config)
-        ]),
-        force_persistence()
-      ])
-    ])
-  end
-
-  def request_body(%VideoEncoderConfiguration{} = video_encoder_config)
-      when not is_nil(video_encoder_config.h264_configuration) and
-             is_nil(video_encoder_config.mpeg4_configuration) do
-    element(:"s:Body", [
-      element(:"trt:SetVideoEncoderConfiguration", [
-        element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
-          name_element(video_encoder_config),
-          use_count_element(video_encoder_config),
-          encoding_element(video_encoder_config),
-          quality_element(video_encoder_config),
-          resolution_element(video_encoder_config),
-          rate_control_element(video_encoder_config),
-          h264_element(video_encoder_config.h264_configuration),
-          multicast_element(video_encoder_config.multicast_configuration),
-          session_timeout_element(video_encoder_config)
-        ]),
-        force_persistence()
-      ])
-    ])
-  end
-
-  def request_body(%VideoEncoderConfiguration{} = video_encoder_config)
-      when is_nil(video_encoder_config.h264_configuration) and
-             not is_nil(video_encoder_config.mpeg4_configuration) do
-    element(:"s:Body", [
-      element(:"trt:SetVideoEncoderConfiguration", [
-        element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
-          name_element(video_encoder_config),
-          use_count_element(video_encoder_config),
-          encoding_element(video_encoder_config),
-          quality_element(video_encoder_config),
-          resolution_element(video_encoder_config),
-          rate_control_element(video_encoder_config),
-          mpeg4_element(video_encoder_config.mpeg4_configuration),
-          multicast_element(video_encoder_config.multicast_configuration),
-          session_timeout_element(video_encoder_config)
-        ]),
-        force_persistence()
-      ])
-    ])
-  end
-
   def request_body(%VideoEncoderConfiguration{} = video_encoder_config) do
     element(:"s:Body", [
       element(:"trt:SetVideoEncoderConfiguration", [
         element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
-          name_element(video_encoder_config),
-          use_count_element(video_encoder_config),
-          encoding_element(video_encoder_config),
-          quality_element(video_encoder_config),
-          resolution_element(video_encoder_config),
-          rate_control_element(video_encoder_config),
+          element(:"tt:Name", video_encoder_config.name),
+          element(:"tt:UseCount", video_encoder_config.use_count),
+          element(
+            :"tt:Encoding",
+            Keyword.fetch!(
+              Ecto.Enum.mappings(video_encoder_config.__struct__, :encoding),
+              video_encoder_config.encoding
+            )
+          ),
+          element(:"tt:Quality", video_encoder_config.quality),
+          element(
+            :"tt:Resolution",
+            [
+              element(:"tt:Width", video_encoder_config.resolution.width),
+              element(:"tt:Height", video_encoder_config.resolution.height)
+            ]
+          ),
+          element(:"tt:RateControl", [
+            element(:"tt:FrameRateLimit", video_encoder_config.rate_control.frame_rate_limit),
+            element(:"tt:EncodingInterval", video_encoder_config.rate_control.encoding_interval),
+            element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
+          ]),
           multicast_element(video_encoder_config.multicast_configuration),
-          session_timeout_element(video_encoder_config)
+          element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
         ]),
-        force_persistence()
+        element(:"trt:ForcePersistence", true)
       ])
     ])
-  end
-
-  defp name_element(video_encoder_config) do
-    element(:"tt:Name", video_encoder_config.name)
-  end
-
-  defp use_count_element(video_encoder_config) do
-    element(:"tt:UseCount", video_encoder_config.use_count)
-  end
-
-  defp encoding_element(video_encoder_config) do
-    element(
-      :"tt:Encoding",
-      Keyword.fetch!(
-        Ecto.Enum.mappings(video_encoder_config.__struct__, :encoding),
-        video_encoder_config.encoding
-      )
-    )
-  end
-
-  defp quality_element(video_encoder_config) do
-    element(:"tt:Quality", video_encoder_config.quality)
-  end
-
-  defp resolution_element(video_encoder_config) do
-    element(
-      :"tt:Resolution",
-      [
-        element(:"tt:Width", video_encoder_config.resolution.width),
-        element(:"tt:Height", video_encoder_config.resolution.height)
-      ]
-    )
-  end
-
-  defp rate_control_element(video_encoder_config) do
-    element(:"tt:RateControl", [
-      element(:"tt:FrameRateLimit", video_encoder_config.rate_control.frame_rate_limit),
-      element(:"tt:EncodingInterval", video_encoder_config.rate_control.encoding_interval),
-      element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
-    ])
-  end
-
-  defp session_timeout_element(video_encoder_config) do
-    element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
-  end
-
-  defp force_persistence do
-    element(:"trt:ForcePersistence", true)
   end
 
   defp multicast_element(%{ip_address: %{type: :ipv4}} = multicast_configuration) do
@@ -174,26 +78,6 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
       element(:"tt:Port", multicast_configuration.port),
       element(:"tt:TTL", multicast_configuration.ttl),
       element(:"tt:AutoStart", multicast_configuration.auto_start)
-    ])
-  end
-
-  defp h264_element(h264_configuration) do
-    element(:"tt:H264", [
-      element(:"tt:GovLength", h264_configuration.gov_length),
-      element(
-        :"tt:H264Profile",
-        Keyword.fetch!(
-          Ecto.Enum.mappings(h264_configuration.__struct__, :h264_profile),
-          h264_configuration.h264_profile
-        )
-      )
-    ])
-  end
-
-  defp mpeg4_element(mpeg4_configuration) do
-    element(:"tt:MPEG4", [
-      element(:"tt:GovLength", mpeg4_configuration.gov_length),
-      element(:"tt:Mpeg4Profile", mpeg4_configuration.h264_profile)
     ])
   end
 

--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -12,36 +12,41 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
     do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
   def request_body(%VideoEncoderConfiguration{} = video_encoder_config) do
-    element(:"s:Body", [
-      element(:"trt:SetVideoEncoderConfiguration", [
-        element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
-          element(:"tt:Name", video_encoder_config.name),
-          element(:"tt:UseCount", video_encoder_config.use_count),
-          element(
-            :"tt:Encoding",
-            Keyword.fetch!(
-              Ecto.Enum.mappings(video_encoder_config.__struct__, :encoding),
-              video_encoder_config.encoding
-            )
-          ),
-          element(:"tt:Quality", video_encoder_config.quality),
-          element(
-            :"tt:Resolution",
-            [
-              element(:"tt:Width", video_encoder_config.resolution.width),
-              element(:"tt:Height", video_encoder_config.resolution.height)
-            ]
-          ),
-          element(:"tt:RateControl", [
-            element(:"tt:FrameRateLimit", video_encoder_config.rate_control.frame_rate_limit),
-            element(:"tt:EncodingInterval", video_encoder_config.rate_control.encoding_interval),
-            element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
+    List.flatten([
+      element(:"s:Body", [
+        element(:"trt:SetVideoEncoderConfiguration", [
+          element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
+            element(:"tt:Name", video_encoder_config.name),
+            element(:"tt:UseCount", video_encoder_config.use_count),
+            element(
+              :"tt:Encoding",
+              Keyword.fetch!(
+                Ecto.Enum.mappings(video_encoder_config.__struct__, :encoding),
+                video_encoder_config.encoding
+              )
+            ),
+            element(:"tt:Quality", video_encoder_config.quality),
+            element(
+              :"tt:Resolution",
+              [
+                element(:"tt:Width", video_encoder_config.resolution.width),
+                element(:"tt:Height", video_encoder_config.resolution.height)
+              ]
+            ),
+            element(:"tt:RateControl", [
+              element(:"tt:FrameRateLimit", video_encoder_config.rate_control.frame_rate_limit),
+              element(
+                :"tt:EncodingInterval",
+                video_encoder_config.rate_control.encoding_interval
+              ),
+              element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
+            ]),
+            encoder_config_element(video_encoder_config),
+            multicast_element(video_encoder_config.multicast_configuration),
+            element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
           ]),
-          List.flatten(encoder_config_element(video_encoder_config)),
-          multicast_element(video_encoder_config.multicast_configuration),
-          element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
-        ]),
-        element(:"trt:ForcePersistence", true)
+          element(:"trt:ForcePersistence", true)
+        ])
       ])
     ])
   end
@@ -100,7 +105,7 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
          h264_configuration: nil,
          mpeg4_configuration: nil
        }) do
-    [{}]
+    []
   end
 
   defp encoder_config_element(%VideoEncoderConfiguration{

--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -37,6 +37,7 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
             element(:"tt:EncodingInterval", video_encoder_config.rate_control.encoding_interval),
             element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
           ]),
+          List.flatten(encoder_config_element(video_encoder_config)),
           multicast_element(video_encoder_config.multicast_configuration),
           element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
         ]),
@@ -93,5 +94,48 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
       )
 
     {:ok, res}
+  end
+
+  defp encoder_config_element(%VideoEncoderConfiguration{
+         h264_configuration: nil,
+         mpeg4_configuration: nil
+       }) do
+    [{}]
+  end
+
+  defp encoder_config_element(%VideoEncoderConfiguration{
+         h264_configuration: h264_configuration,
+         mpeg4_configuration: nil
+       }) do
+    [
+      element(:"tt:H264", [
+        element(:"tt:GovLength", h264_configuration.gov_length),
+        element(
+          :"tt:H264Profile",
+          Keyword.fetch!(
+            Ecto.Enum.mappings(h264_configuration.__struct__, :h264_profile),
+            h264_configuration.h264_profile
+          )
+        )
+      ])
+    ]
+  end
+
+  defp encoder_config_element(%VideoEncoderConfiguration{
+         h264_configuration: nil,
+         mpeg4_configuration: mpeg4_configuration
+       }) do
+    [
+      element(:"tt:MPEG4", [
+        element(:"tt:GovLength", mpeg4_configuration.gov_length),
+        element(
+          :"tt:Mpeg4Profile",
+          Keyword.fetch!(
+            Ecto.Enum.mappings(mpeg4_configuration.__struct__, :mpeg4_profile),
+            mpeg4_configuration.mpeg4_profile
+          )
+        )
+      ])
+    ]
   end
 end

--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -11,38 +11,134 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
   def request(device, args),
     do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
+  def request_body(%VideoEncoderConfiguration{} = video_encoder_config)
+      when not is_nil(video_encoder_config.h264_configuration) and
+             not is_nil(video_encoder_config.mpeg4_configuration) do
+    element(:"s:Body", [
+      element(:"trt:SetVideoEncoderConfiguration", [
+        element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
+          name_element(video_encoder_config),
+          use_count_element(video_encoder_config),
+          encoding_element(video_encoder_config),
+          quality_element(video_encoder_config),
+          resolution_element(video_encoder_config),
+          rate_control_element(video_encoder_config),
+          h264_element(video_encoder_config.h264_configuration),
+          mpeg4_element(video_encoder_config.mpeg4_configuration),
+          multicast_element(video_encoder_config.multicast_configuration),
+          session_timeout_element(video_encoder_config)
+        ]),
+        force_persistence()
+      ])
+    ])
+  end
+
+  def request_body(%VideoEncoderConfiguration{} = video_encoder_config)
+      when not is_nil(video_encoder_config.h264_configuration) and
+             is_nil(video_encoder_config.mpeg4_configuration) do
+    element(:"s:Body", [
+      element(:"trt:SetVideoEncoderConfiguration", [
+        element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
+          name_element(video_encoder_config),
+          use_count_element(video_encoder_config),
+          encoding_element(video_encoder_config),
+          quality_element(video_encoder_config),
+          resolution_element(video_encoder_config),
+          rate_control_element(video_encoder_config),
+          h264_element(video_encoder_config.h264_configuration),
+          multicast_element(video_encoder_config.multicast_configuration),
+          session_timeout_element(video_encoder_config)
+        ]),
+        force_persistence()
+      ])
+    ])
+  end
+
+  def request_body(%VideoEncoderConfiguration{} = video_encoder_config)
+      when is_nil(video_encoder_config.h264_configuration) and
+             not is_nil(video_encoder_config.mpeg4_configuration) do
+    element(:"s:Body", [
+      element(:"trt:SetVideoEncoderConfiguration", [
+        element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
+          name_element(video_encoder_config),
+          use_count_element(video_encoder_config),
+          encoding_element(video_encoder_config),
+          quality_element(video_encoder_config),
+          resolution_element(video_encoder_config),
+          rate_control_element(video_encoder_config),
+          mpeg4_element(video_encoder_config.mpeg4_configuration),
+          multicast_element(video_encoder_config.multicast_configuration),
+          session_timeout_element(video_encoder_config)
+        ]),
+        force_persistence()
+      ])
+    ])
+  end
+
   def request_body(%VideoEncoderConfiguration{} = video_encoder_config) do
     element(:"s:Body", [
       element(:"trt:SetVideoEncoderConfiguration", [
         element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
-          element(:"tt:Name", video_encoder_config.name),
-          element(:"tt:UseCount", video_encoder_config.use_count),
-          element(
-            :"tt:Encoding",
-            Keyword.fetch!(
-              Ecto.Enum.mappings(video_encoder_config.__struct__, :encoding),
-              video_encoder_config.encoding
-            )
-          ),
-          element(:"tt:Quality", video_encoder_config.quality),
-          element(
-            :"tt:Resolution",
-            [
-              element(:"tt:Width", video_encoder_config.resolution.width),
-              element(:"tt:Height", video_encoder_config.resolution.height)
-            ]
-          ),
-          element(:"tt:RateControl", [
-            element(:"tt:FrameRateLimit", video_encoder_config.rate_control.frame_rate_limit),
-            element(:"tt:EncodingInterval", video_encoder_config.rate_control.encoding_interval),
-            element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
-          ]),
+          name_element(video_encoder_config),
+          use_count_element(video_encoder_config),
+          encoding_element(video_encoder_config),
+          quality_element(video_encoder_config),
+          resolution_element(video_encoder_config),
+          rate_control_element(video_encoder_config),
           multicast_element(video_encoder_config.multicast_configuration),
-          element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
+          session_timeout_element(video_encoder_config)
         ]),
-        element(:"trt:ForcePersistence", true)
+        force_persistence()
       ])
     ])
+  end
+
+  defp name_element(video_encoder_config) do
+    element(:"tt:Name", video_encoder_config.name)
+  end
+
+  defp use_count_element(video_encoder_config) do
+    element(:"tt:UseCount", video_encoder_config.use_count)
+  end
+
+  defp encoding_element(video_encoder_config) do
+    element(
+      :"tt:Encoding",
+      Keyword.fetch!(
+        Ecto.Enum.mappings(video_encoder_config.__struct__, :encoding),
+        video_encoder_config.encoding
+      )
+    )
+  end
+
+  defp quality_element(video_encoder_config) do
+    element(:"tt:Quality", video_encoder_config.quality)
+  end
+
+  defp resolution_element(video_encoder_config) do
+    element(
+      :"tt:Resolution",
+      [
+        element(:"tt:Width", video_encoder_config.resolution.width),
+        element(:"tt:Height", video_encoder_config.resolution.height)
+      ]
+    )
+  end
+
+  defp rate_control_element(video_encoder_config) do
+    element(:"tt:RateControl", [
+      element(:"tt:FrameRateLimit", video_encoder_config.rate_control.frame_rate_limit),
+      element(:"tt:EncodingInterval", video_encoder_config.rate_control.encoding_interval),
+      element(:"tt:BitrateLimit", video_encoder_config.rate_control.bitrate_limit)
+    ])
+  end
+
+  defp session_timeout_element(video_encoder_config) do
+    element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
+  end
+
+  defp force_persistence do
+    element(:"trt:ForcePersistence", true)
   end
 
   defp multicast_element(%{ip_address: %{type: :ipv4}} = multicast_configuration) do
@@ -78,6 +174,26 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
       element(:"tt:Port", multicast_configuration.port),
       element(:"tt:TTL", multicast_configuration.ttl),
       element(:"tt:AutoStart", multicast_configuration.auto_start)
+    ])
+  end
+
+  defp h264_element(h264_configuration) do
+    element(:"tt:H264", [
+      element(:"tt:GovLength", h264_configuration.gov_length),
+      element(
+        :"tt:H264Profile",
+        Keyword.fetch!(
+          Ecto.Enum.mappings(h264_configuration.__struct__, :h264_profile),
+          h264_configuration.h264_profile
+        )
+      )
+    ])
+  end
+
+  defp mpeg4_element(mpeg4_configuration) do
+    element(:"tt:MPEG4", [
+      element(:"tt:GovLength", mpeg4_configuration.gov_length),
+      element(:"tt:Mpeg4Profile", mpeg4_configuration.h264_profile)
     ])
   end
 

--- a/lib/media/ver10/set_video_encoder_configuration.ex
+++ b/lib/media/ver10/set_video_encoder_configuration.ex
@@ -12,10 +12,12 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
     do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
   def request_body(%VideoEncoderConfiguration{} = video_encoder_config) do
-    List.flatten([
-      element(:"s:Body", [
-        element(:"trt:SetVideoEncoderConfiguration", [
-          element(:"trt:Configuration", %{"token" => video_encoder_config.reference_token}, [
+    element(:"s:Body", [
+      element(:"trt:SetVideoEncoderConfiguration", [
+        element(
+          :"trt:Configuration",
+          %{"token" => video_encoder_config.reference_token},
+          List.flatten([
             element(:"tt:Name", video_encoder_config.name),
             element(:"tt:UseCount", video_encoder_config.use_count),
             element(
@@ -44,9 +46,9 @@ defmodule Onvif.Media.Ver10.SetVideoEncoderConfiguration do
             encoder_config_element(video_encoder_config),
             multicast_element(video_encoder_config.multicast_configuration),
             element(:"tt:SessionTimeout", video_encoder_config.session_timeout)
-          ]),
-          element(:"trt:ForcePersistence", true)
-        ])
+          ])
+        ),
+        element(:"trt:ForcePersistence", true)
       ])
     ])
   end


### PR DESCRIPTION
- Tested in axis and uniview.
- There might be a cleaner way to do this but I couldn't figure it out. Axis fails for an empty tag for both optional configs (h264 and mpeg4). So I came up with guards. If there is any better way will change it to that.