### PR TITLE
Enable loopback in WS discovery

### DIFF
--- a/lib/device.ex
+++ b/lib/device.ex
@@ -75,8 +75,8 @@ defmodule Onvif.Device do
           | {:ok, __MODULE__.t()}
   def init(
         %Probe{} = probe_match,
-        username \\ "",
-        password \\ "",
+        username,
+        password,
         prefer_https? \\ false,
         prefer_ipv6? \\ false
       ) do

--- a/lib/device.ex
+++ b/lib/device.ex
@@ -75,8 +75,8 @@ defmodule Onvif.Device do
           | {:ok, __MODULE__.t()}
   def init(
         %Probe{} = probe_match,
-        username,
-        password,
+        username \\ "",
+        password \\ "",
         prefer_https? \\ false,
         prefer_ipv6? \\ false
       ) do

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -43,7 +43,7 @@ defmodule Onvif.Discovery do
   @spec probe(Keyword.t()) :: list(Probe.t())
   def probe(opts \\ [probe_timeout: @probe_timeout_msec]) do
     payload = probe_payload()
-    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: false)
+    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: true)
     :gen_udp.send(socket, @onvif_discovery_ip, @onvif_discovery_port, payload)
 
     receive_message(socket, opts, [])

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -35,15 +35,18 @@ defmodule Onvif.Discovery do
   Duplicate probes may be returned and it is up to the calling application to
   choose how to filter out a duplicate.
 
-  `opts` are a keyword list of options, currently just `:probe_timeout` which is
-  how long the probe will wait between new probe responses before closing out the
+  `opts` are a keyword list of options,
+  - `:probe_timeout` which is how long the probe will wait between new probe responses before closing out the
   listener. There currently is no forced duration so if the network continuously
   generates probe messages this has the possibility to hang.
+  - `:multicat_loop?` defaults to false. Enabling it will allow host to echoing the multicast packets back to itself.
+  This is useful when this library runs in same device where you simulate a ONVIF device (https://www.happytimesoft.com/products/onvif-server/index.html)
   """
   @spec probe(Keyword.t()) :: list(Probe.t())
-  def probe(opts \\ [probe_timeout: @probe_timeout_msec]) do
+  def probe(opts \\ [probe_timeout: @probe_timeout_msec, multicat_loop?: false]) do
     payload = probe_payload()
-    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: true)
+    multicat_loop? = Keyword.get(opts, :multicat_loop?, false)
+    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: multicat_loop?)
     :gen_udp.send(socket, @onvif_discovery_ip, @onvif_discovery_port, payload)
 
     receive_message(socket, opts, [])

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -39,14 +39,14 @@ defmodule Onvif.Discovery do
   - `:probe_timeout` denotes how long the probe will wait between new probe responses before closing out the
   listener. There currently is no forced duration so if the network continuously
   generates probe messages this has the possibility to hang.
-  - `:multicast_loop?` defaults to false. Enabling it will allow host to echoing the multicast packets back to itself.
+  - `:multicast_loop` defaults to false. Enabling it will allow host to echoing the multicast packets back to itself.
   This is useful when this library runs in same device where you simulate a ONVIF device (https://www.happytimesoft.com/products/onvif-server/index.html)
   """
   @spec probe(Keyword.t()) :: list(Probe.t())
-  def probe(opts \\ [probe_timeout: @probe_timeout_msec, multicast_loop?: false]) do
+  def probe(opts \\ [probe_timeout: @probe_timeout_msec, multicast_loop: false]) do
     payload = probe_payload()
-    multicast_loop? = Keyword.get(opts, :multicast_loop?, false)
-    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: multicast_loop?)
+    multicast_loop = Keyword.get(opts, :multicast_loop, false)
+    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: multicast_loop)
     :gen_udp.send(socket, @onvif_discovery_ip, @onvif_discovery_port, payload)
 
     receive_message(socket, opts, [])

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -39,14 +39,14 @@ defmodule Onvif.Discovery do
   - `:probe_timeout` which is how long the probe will wait between new probe responses before closing out the
   listener. There currently is no forced duration so if the network continuously
   generates probe messages this has the possibility to hang.
-  - `:multicat_loop?` defaults to false. Enabling it will allow host to echoing the multicast packets back to itself.
+  - `:multicast_loop?` defaults to false. Enabling it will allow host to echoing the multicast packets back to itself.
   This is useful when this library runs in same device where you simulate a ONVIF device (https://www.happytimesoft.com/products/onvif-server/index.html)
   """
   @spec probe(Keyword.t()) :: list(Probe.t())
-  def probe(opts \\ [probe_timeout: @probe_timeout_msec, multicat_loop?: false]) do
+  def probe(opts \\ [probe_timeout: @probe_timeout_msec, multicast_loop?: false]) do
     payload = probe_payload()
-    multicat_loop? = Keyword.get(opts, :multicat_loop?, false)
-    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: multicat_loop?)
+    multicast_loop? = Keyword.get(opts, :multicast_loop?, false)
+    {:ok, socket} = :gen_udp.open(0, mode: :binary, active: true, multicast_loop: multicast_loop?)
     :gen_udp.send(socket, @onvif_discovery_ip, @onvif_discovery_port, payload)
 
     receive_message(socket, opts, [])

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -36,7 +36,7 @@ defmodule Onvif.Discovery do
   choose how to filter out a duplicate.
 
   `opts` are a keyword list of options,
-  - `:probe_timeout` which is how long the probe will wait between new probe responses before closing out the
+  - `:probe_timeout` denotes how long the probe will wait between new probe responses before closing out the
   listener. There currently is no forced duration so if the network continuously
   generates probe messages this has the possibility to hang.
   - `:multicast_loop?` defaults to false. Enabling it will allow host to echoing the multicast packets back to itself.


### PR DESCRIPTION
ODM is able to discover the devices from https://www.happytimesoft.com/products/onvif-server/index.html. Only if we enable loopback we are able to replicate the ODM behavior.

