### PR TITLE
Remove userinfo from device.address

### DIFF
--- a/lib/api.ex
+++ b/lib/api.ex
@@ -6,12 +6,10 @@ defmodule Onvif.API do
     adapter = {Tesla.Adapter.Finch, name: Onvif.Finch}
     service_path = get_service_path!(device, opts)
 
-    uri = device.address <> service_path
-    parsed_uri = URI.parse(uri)
-    no_userinfo_uri = %URI{parsed_uri | userinfo: nil} |> URI.to_string()
+    url = device.address <> service_path
 
     middleware = [
-      {Tesla.Middleware.BaseUrl, no_userinfo_uri},
+      {Tesla.Middleware.BaseUrl, url},
       auth_function(device),
       {Tesla.Middleware.Logger, log_level: :info},
       {Tesla.Middleware.Headers,

--- a/lib/device.ex
+++ b/lib/device.ex
@@ -103,7 +103,6 @@ defmodule Onvif.Device do
       |> get_address(prefer_ipv6?, prefer_https?)
       |> URI.parse()
       |> Map.put(:path, "")
-      |> Map.put(:userinfo, "#{username}:#{password}")
 
     device = %Device{
       username: username,


### PR DESCRIPTION
- Earlier we got the username and password from the URL but since we changed to %Device{} it is not needed.
- This also creates issue if the username and password is not properly encoded

Example

```
iex(3)> URI.parse("admin#:admin#@http://192.168.14.225:80/onvif/")
%URI{
  authority: nil,
  fragment: ":admin#@http://192.168.14.225:80/onvif/",
  host: nil,
  path: "admin",
  port: nil,
  query: nil,
  scheme: nil,
  userinfo: nil
}
```

I checked our usages of `URI.parse/1`, we are only passing it the address from the ONVIF probe match which doesn't have `userinfo` i.e. username and password in the address so we don't need to worry about encoding the same.