### PR TITLE
Stop reusing TCP connection with Tesla

### DIFF
--- a/lib/api.ex
+++ b/lib/api.ex
@@ -11,11 +11,7 @@ defmodule Onvif.API do
     middleware = [
       {Tesla.Middleware.BaseUrl, url},
       auth_function(device),
-      {Tesla.Middleware.Logger, log_level: :info},
-      {Tesla.Middleware.Headers,
-       [
-         {"connection", "keep-alive"}
-       ]}
+      {Tesla.Middleware.Logger, log_level: :info}
     ]
 
     Tesla.client(middleware, adapter)


### PR DESCRIPTION
- This causes issue when chaining multiple ONVIF API calls like `GetProfiles -> GetSnapshotUri -> GetNetworkInterfaces` i.e if `GetSnapshotUri` fails, the tesla env won't have required headers use digest auth for the `GetNetworkInterfaces` call.
```
%FunctionClauseError{args: nil, arity: 1, clauses: nil, function: :response, kind: nil, module: Onvif.Middleware.DigestAuth}
```