### PR TITLE
Handle invalid services

### DIFF
--- a/lib/devices/service.ex
+++ b/lib/devices/service.ex
@@ -8,7 +8,7 @@ defmodule Onvif.Device.Service do
   import Ecto.Changeset
   import SweetXml
 
-  @profile_permitted [:namespace, :xaddr, :version]
+  @required [:namespace, :xaddr, :version]
 
   @primary_key false
   @derive Jason.Encoder
@@ -36,6 +36,7 @@ defmodule Onvif.Device.Service do
   def to_struct(parsed) do
     %__MODULE__{}
     |> changeset(parsed)
+    |> validate_required(@required)
     |> apply_action(:validate)
   end
 
@@ -52,6 +53,6 @@ defmodule Onvif.Device.Service do
   end
 
   def changeset(module, attrs) do
-    cast(module, attrs, @profile_permitted)
+    cast(module, attrs, @required)
   end
 end


### PR DESCRIPTION
- Some devices are returning invalid services for `GetServices` API i.e. `%Onvif.Device.Service{namespace: nil, version: ".", xaddr: nil}`. 
- According to the spec `namespace`, `version` and `xaddr` all three are required. So enforced it in the `Onvif.Device.Service` changeset. We are filtering out the error tuple at the [device service layer](https://github.com/hammeraj/onvif/blob/main/lib/devices/get_services.ex#L39).