### PR TITLE
Handle self closing tags

### DIFF
--- a/lib/devices/network_interface.ex
+++ b/lib/devices/network_interface.ex
@@ -123,6 +123,9 @@ defmodule Onvif.Device.NetworkInterface do
     end
   end
 
+  def parse(nil), do: nil
+  def parse([]), do: nil
+
   def parse(doc) do
     xmap(
       doc,
@@ -146,6 +149,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_info(nil), do: nil
+  defp parse_info([]), do: nil
 
   defp parse_info(doc) do
     xmap(
@@ -157,6 +161,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_link(nil), do: nil
+  defp parse_link([]), do: nil
 
   defp parse_link(doc) do
     xmap(
@@ -168,6 +173,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_ipv4(nil), do: nil
+  defp parse_ipv4([]), do: nil
 
   defp parse_ipv4(doc) do
     xmap(
@@ -178,6 +184,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_ipv6(nil), do: nil
+  defp parse_ipv6([]), do: nil
 
   defp parse_ipv6(doc) do
     xmap(
@@ -188,6 +195,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_connection_settings(nil), do: nil
+  defp parse_connection_settings([]), do: nil
 
   defp parse_connection_settings(doc) do
     xmap(
@@ -199,6 +207,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_ipv4_config(nil), do: nil
+  defp parse_ipv4_config([]), do: nil
 
   defp parse_ipv4_config(doc) do
     xmap(
@@ -211,6 +220,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_ipv6_config(nil), do: nil
+  defp parse_ipv6_config([]), do: nil
 
   defp parse_ipv6_config(doc) do
     xmap(
@@ -225,6 +235,7 @@ defmodule Onvif.Device.NetworkInterface do
   end
 
   defp parse_address(nil), do: nil
+  defp parse_address([]), do: nil
 
   defp parse_address(doc) do
     xmap(

--- a/lib/devices/service.ex
+++ b/lib/devices/service.ex
@@ -18,6 +18,9 @@ defmodule Onvif.Device.Service do
     field(:version, :string)
   end
 
+  def parse(nil), do: nil
+  def parse([]), do: nil
+
   def parse(doc) do
     version =
       xmap(doc,

--- a/lib/media/ver10/profile/analytics_engine_configuration.ex
+++ b/lib/media/ver10/profile/analytics_engine_configuration.ex
@@ -23,19 +23,16 @@ defmodule Onvif.Media.Ver10.Profile.AnalyticsEngineConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
-    try do
-      xmap(
-        doc,
-        analytics_module: ~x"./tt:AnalyticsModule"el |> transform_by(&parse_analytics_module/1)
-      )
-    catch
-      :exit, reason ->
-        Logger.error("Skipping invalid AnalyticsModule. Error: #{inspect(reason)}")
-        %{analytics_module: []}
-    end
+    xmap(
+      doc,
+      analytics_module: ~x"./tt:AnalyticsModule"el |> transform_by(&parse_analytics_module/1)
+    )
   end
+
+  defp parse_analytics_module([]), do: []
 
   defp parse_analytics_module(nil), do: nil
 

--- a/lib/media/ver10/profile/analytics_engine_configuration.ex
+++ b/lib/media/ver10/profile/analytics_engine_configuration.ex
@@ -7,6 +7,7 @@ defmodule Onvif.Media.Ver10.Profile.AnalyticsEngineConfiguration do
   import Ecto.Changeset
   import SweetXml
 
+  require Logger
   alias Onvif.Media.Ver10.Profile.Parameters
 
   @primary_key false
@@ -24,10 +25,16 @@ defmodule Onvif.Media.Ver10.Profile.AnalyticsEngineConfiguration do
   def parse(nil), do: nil
 
   def parse(doc) do
-    xmap(
-      doc,
-      analytics_module: ~x"./tt:AnalyticsModule"el |> transform_by(&parse_analytics_module/1)
-    )
+    try do
+      xmap(
+        doc,
+        analytics_module: ~x"./tt:AnalyticsModule"el |> transform_by(&parse_analytics_module/1)
+      )
+    catch
+      :exit, reason ->
+        Logger.error("Skipping invalid AnalyticsModule. Error: #{inspect(reason)}")
+        %{analytics_module: []}
+    end
   end
 
   defp parse_analytics_module(nil), do: nil

--- a/lib/media/ver10/profile/audio_encoder_configuration.ex
+++ b/lib/media/ver10/profile/audio_encoder_configuration.ex
@@ -28,6 +28,7 @@ defmodule Onvif.Media.Ver10.Profile.AudioEncoderConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(

--- a/lib/media/ver10/profile/audio_source_configuration.ex
+++ b/lib/media/ver10/profile/audio_source_configuration.ex
@@ -17,6 +17,7 @@ defmodule Onvif.Media.Ver10.Profile.AudioSourceConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(

--- a/lib/media/ver10/profile/metadata_configuration.ex
+++ b/lib/media/ver10/profile/metadata_configuration.ex
@@ -32,6 +32,7 @@ defmodule Onvif.Media.Ver10.Profile.MetadataConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(
@@ -54,6 +55,7 @@ defmodule Onvif.Media.Ver10.Profile.MetadataConfiguration do
   end
 
   defp parse_ptz_status(nil), do: nil
+  defp parse_ptz_status([]), do: nil
 
   defp parse_ptz_status(doc) do
     xmap(

--- a/lib/media/ver10/profile/multicast_configuration.ex
+++ b/lib/media/ver10/profile/multicast_configuration.ex
@@ -23,6 +23,7 @@ defmodule Onvif.Media.Ver10.Profile.MulticastConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(
@@ -35,6 +36,7 @@ defmodule Onvif.Media.Ver10.Profile.MulticastConfiguration do
   end
 
   defp parse_address(nil), do: nil
+  defp parse_address([]), do: nil
 
   defp parse_address(doc) do
     xmap(

--- a/lib/media/ver10/profile/parameters.ex
+++ b/lib/media/ver10/profile/parameters.ex
@@ -22,6 +22,8 @@ defmodule Onvif.Media.Ver10.Profile.Parameters do
     end
   end
 
+  def parse([]), do: []
+
   def parse(doc) do
     xmap(
       doc,

--- a/lib/media/ver10/profile/profile.ex
+++ b/lib/media/ver10/profile/profile.ex
@@ -54,6 +54,8 @@ defmodule Onvif.Media.Ver10.Profile do
     end
   end
 
+  def parse([]), do: nil
+
   def parse(doc) do
     xmap(
       doc,

--- a/lib/media/ver10/profile/video_analytics_configuration.ex
+++ b/lib/media/ver10/profile/video_analytics_configuration.ex
@@ -33,6 +33,7 @@ defmodule Onvif.Media.Ver10.Profile.VideoAnalyticsConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(
@@ -49,6 +50,7 @@ defmodule Onvif.Media.Ver10.Profile.VideoAnalyticsConfiguration do
   end
 
   defp parse_rule_engine_configuration(nil), do: nil
+  defp parse_rule_engine_configuration([]), do: nil
 
   defp parse_rule_engine_configuration(doc) do
     xmap(
@@ -58,6 +60,7 @@ defmodule Onvif.Media.Ver10.Profile.VideoAnalyticsConfiguration do
   end
 
   defp parse_rule(nil), do: nil
+  defp parse_rule([]), do: nil
 
   defp parse_rule([_ | _] = rules), do: Enum.map(rules, &parse_rule/1)
 

--- a/lib/media/ver10/profile/video_encoder_configuration.ex
+++ b/lib/media/ver10/profile/video_encoder_configuration.ex
@@ -52,6 +52,7 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(
@@ -72,6 +73,8 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfiguration do
     )
   end
 
+  defp parse_resolution([]), do: nil
+
   defp parse_resolution(doc) do
     xmap(
       doc,
@@ -79,6 +82,8 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfiguration do
       height: ~x"./tt:Height/text()"i
     )
   end
+
+  defp parse_rate_control([]), do: nil
 
   defp parse_rate_control(doc) do
     xmap(
@@ -89,6 +94,7 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfiguration do
     )
   end
 
+  defp parse_mpeg4_configuration([]), do: nil
   defp parse_mpeg4_configuration(nil), do: nil
 
   defp parse_mpeg4_configuration(doc) do
@@ -99,6 +105,7 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfiguration do
     )
   end
 
+  defp parse_h264_configuration([]), do: nil
   defp parse_h264_configuration(nil), do: nil
 
   defp parse_h264_configuration(doc) do

--- a/lib/media/ver10/profile/video_encoder_configuration_option.ex
+++ b/lib/media/ver10/profile/video_encoder_configuration_option.ex
@@ -325,6 +325,10 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption do
     nil
   end
 
+  defp parse_jpeg([]) do
+    nil
+  end
+
   defp parse_jpeg(doc) do
     xmap(
       doc,
@@ -338,6 +342,10 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption do
   end
 
   defp parse_mpeg4(nil) do
+    nil
+  end
+
+  defp parse_mpeg4([]) do
     nil
   end
 
@@ -359,6 +367,10 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption do
     nil
   end
 
+  defp parse_h264([]) do
+    nil
+  end
+
   defp parse_h264(doc) do
     xmap(
       doc,
@@ -374,6 +386,10 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption do
   end
 
   defp parse_extension(nil) do
+    nil
+  end
+
+  defp parse_extension([]) do
     nil
   end
 
@@ -394,6 +410,10 @@ defmodule Onvif.Media.Ver10.Profile.VideoEncoderConfigurationOption do
         height: ~x"./tt:Height/text()"i
       )
     end)
+  end
+
+  defp parse_int_range([]) do
+    nil
   end
 
   defp parse_int_range(nil) do

--- a/lib/media/ver10/profile/video_source_configuration.ex
+++ b/lib/media/ver10/profile/video_source_configuration.ex
@@ -62,6 +62,7 @@ defmodule Onvif.Media.Ver10.Profile.VideoSourceConfiguration do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(
@@ -74,6 +75,8 @@ defmodule Onvif.Media.Ver10.Profile.VideoSourceConfiguration do
       bounds: ~x"./tt:Bounds"e |> transform_by(&parse_bounds/1)
     )
   end
+
+  defp parse_bounds([]), do: nil
 
   defp parse_bounds(doc) do
     xmap(

--- a/lib/media/ver20/profile/profile.ex
+++ b/lib/media/ver20/profile/profile.ex
@@ -55,6 +55,9 @@ defmodule Onvif.Media.Ver20.Profile do
     end
   end
 
+  def parse(nil), do: nil
+  def parse([]), do: nil
+
   def parse(doc) do
     xmap(
       doc,

--- a/lib/media/ver20/profile/video_encoder.ex
+++ b/lib/media/ver20/profile/video_encoder.ex
@@ -40,6 +40,7 @@ defmodule Onvif.Media.Ver20.Profile.VideoEncoder do
   end
 
   def parse(nil), do: nil
+  def parse([]), do: nil
 
   def parse(doc) do
     xmap(


### PR DESCRIPTION
When we are encountering self closing tags like `<tt:AnalyticsEngineConfiguration/>` our transform_by crashes since we don't have a pattern match for empty tag. Added the pattern match for all our parse functions.