### PR TITLE
Remove redundant datetime calls in XML auth

### DIFF
--- a/lib/media/ver10/profile/analytics_engine_configuration.ex
+++ b/lib/media/ver10/profile/analytics_engine_configuration.ex
@@ -7,7 +7,6 @@ defmodule Onvif.Media.Ver10.Profile.AnalyticsEngineConfiguration do
   import Ecto.Changeset
   import SweetXml
 
-  require Logger
   alias Onvif.Media.Ver10.Profile.Parameters
 
   @primary_key false

--- a/lib/middleware/xml_auth.ex
+++ b/lib/middleware/xml_auth.ex
@@ -43,10 +43,10 @@ defmodule Onvif.Middleware.XmlAuth do
   end
 
   defp generate_xml_auth_header(device: device) do
-    {:ok, system_date} = Onvif.Devices.GetSystemDateAndTime.request(device)
-
     created_at =
-      DateTime.utc_now() |> DateTime.add(system_date.current_diff) |> DateTime.to_iso8601()
+      DateTime.utc_now()
+      |> DateTime.add(device.time_diff_from_system_secs)
+      |> DateTime.to_iso8601()
 
     nonce_bytes = :rand.bytes(@nonce_bytesize)
     nonce = Base.encode64(nonce_bytes)


### PR DESCRIPTION
Since we already have datatime diff stored in device we can avoid the redundant call in XML auth.