### PR TITLE
Make username and password optional

### DIFF
--- a/lib/device.ex
+++ b/lib/device.ex
@@ -5,8 +5,10 @@ defmodule Onvif.Device do
   alias Onvif.Device
   alias Onvif.Discovery.Probe
 
-  @required [:username, :password, :address]
+  @required [:address]
   @optional [
+    :username,
+    :password,
     :scopes,
     :manufacturer,
     :model,


### PR DESCRIPTION
With `:no_auth` username and password can be blank.