### PR TITLE
Patch audio_encoder_options

### DIFF
--- a/lib/media/ver10/get_audio_encoder_configuration_options.ex
+++ b/lib/media/ver10/get_audio_encoder_configuration_options.ex
@@ -10,7 +10,7 @@ defmodule Onvif.Media.Ver10.GetAudioEncoderConfigurationOptions do
   def soap_action, do: "http://www.onvif.org/ver10/media/wsdl/GetAudioEncoderConfigurationOptions"
 
   @spec request(Device.t(), list) :: {:ok, any} | {:error, map()}
-  def request(device, args),
+  def request(device, args \\ []),
     do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
   def request_body() do

--- a/lib/media/ver10/get_audio_encoder_configuration_options.ex
+++ b/lib/media/ver10/get_audio_encoder_configuration_options.ex
@@ -13,25 +13,27 @@ defmodule Onvif.Media.Ver10.GetAudioEncoderConfigurationOptions do
   def request(device, args),
     do: Onvif.Media.Ver10.Media.request(device, args, __MODULE__)
 
-  def request_body(configuration_token, profile_token) do
+  def request_body() do
+    element(:"s:Body", [
+      element(:"trt:GetAudioEncoderConfigurationOptions")
+    ])
+  end
+
+  def request_body(configuration_token) do
     element(:"s:Body", [
       element(:"trt:GetAudioEncoderConfigurationOptions", [
-        gen_config_token_element(configuration_token),
-        gen_profile_token_element(profile_token)
+        element(:"trt:ConfigurationToken", configuration_token)
       ])
     ])
   end
 
-  def gen_profile_token_element(nil), do: []
-
-  def gen_profile_token_element(profile_token) do
-    element(:"trt:ProfileToken", profile_token)
-  end
-
-  def gen_config_token_element(nil), do: []
-
-  def gen_config_token_element(configuration_token) do
-    element(:"trt:ConfigurationToken", configuration_token)
+  def request_body(configuration_token, profile_token) do
+    element(:"s:Body", [
+      element(:"trt:GetAudioEncoderConfigurationOptions", [
+        element(:"trt:ConfigurationToken", configuration_token),
+        element(:"trt:ProfileToken", profile_token)
+      ])
+    ])
   end
 
   @spec response(any) :: {:error, Ecto.Changeset.t()} | {:ok, struct()}

--- a/test/media/ver10/get_audio_encoder_configuration_options_test.exs
+++ b/test/media/ver10/get_audio_encoder_configuration_options_test.exs
@@ -17,7 +17,7 @@ defmodule Onvif.Media.Ver10.GetAudioEncoderConfigurationOptionsTest do
       end)
 
       {:ok, response} =
-        Onvif.Media.Ver10.GetAudioEncoderConfigurationOptions.request(device, [nil, nil])
+        Onvif.Media.Ver10.GetAudioEncoderConfigurationOptions.request(device)
 
       assert response == [
                %Onvif.Media.Ver10.Profile.AudioEncoderConfigurationOption{


### PR DESCRIPTION
## What and Why
patch **GetAudioEncoderConfigurationOptions** to allow the usage without the explicit `nil` for tokens.

## Verification Steps
- `mix test test/media/ver10/get_audio_encoder_configuration_options_test.exs`
- `Onvif.Media.Ver10.GetAudioEncoderConfigurationOptions.request`

## Tested on
- [x] Axis
- [x] Uniview
- [x] Hikivision
- [x] Dahua