### PR TITLE
Filter out link local addresses when initializing device

### DIFF
--- a/lib/device.ex
+++ b/lib/device.ex
@@ -202,8 +202,10 @@ defmodule Onvif.Device do
           |> :inet.parse_ipv6strict_address()
 
         case result do
-          {:ok, _} ->
+          {:ok, addr} ->
             cond do
+              # ignore link-local addresses
+              match?({0xFE80, _, _, _, _, _, _, _}, addr) -> false
               prefer_https? -> String.contains?(address, "https://")
               true -> true
             end
@@ -223,8 +225,10 @@ defmodule Onvif.Device do
           |> :inet.parse_ipv4strict_address()
 
         case result do
-          {:ok, _} ->
+          {:ok, addr} ->
             cond do
+              # ignore link-local addresses
+              match?({169, 254, _, _}, addr) -> false
               prefer_https? -> String.contains?(address, "https://")
               true -> true
             end


### PR DESCRIPTION
Some axis cameras include link-local addresses in the onvif probe response which are not reachable when initializing the device. In this PR we filter out those addresses.