### PR TITLE
Allow providing only profile token in get video encoder configuration

### DIFF
--- a/lib/media/ver20/get_video_encoder_configurations.ex
+++ b/lib/media/ver20/get_video_encoder_configurations.ex
@@ -14,26 +14,12 @@ defmodule Onvif.Media.Ver20.GetVideoEncoderConfigurations do
   def request(device, args \\ []),
     do: Onvif.Media.Ver20.Media.request(device, args, __MODULE__)
 
-  def request_body() do
-    element(:"s:Body", [
-      element(:"tr2:GetVideoEncoderConfigurations")
-    ])
-  end
+  def request_body(configuration_token \\ nil, profile_token \\ nil) do
+    config =
+      with_configuration_token([], configuration_token) |> with_profile_token(profile_token)
 
-  def request_body(configuration_token) do
     element(:"s:Body", [
-      element(:"tr2:GetVideoEncoderConfigurations", [
-        element(:"tr2:ConfigurationToken", configuration_token)
-      ])
-    ])
-  end
-
-  def request_body(configuration_token, profile_token) do
-    element(:"s:Body", [
-      element(:"tr2:GetVideoEncoderConfigurations", [
-        element(:"tr2:ConfigurationToken", configuration_token),
-        element(:"tr2:ProfileToken", profile_token)
-      ])
+      element(:"tr2:GetVideoEncoderConfigurations", config)
     ])
   end
 
@@ -61,5 +47,17 @@ defmodule Onvif.Media.Ver20.GetVideoEncoderConfigurations do
       end)
 
     {:ok, response}
+  end
+
+  defp with_configuration_token(config, nil), do: config
+
+  defp with_configuration_token(config, configuration_token) do
+    [element(:"tr2:ConfigurationToken", configuration_token) | config]
+  end
+
+  defp with_profile_token(config, nil), do: config
+
+  defp with_profile_token(config, profile_token) do
+    [element(:"tr2:ProfileToken", profile_token) | config]
   end
 end

--- a/test/devices/get_network_protocols_test.exs
+++ b/test/devices/get_network_protocols_test.exs
@@ -25,7 +25,9 @@ defmodule Onvif.Devices.GetNetworkProtocolsTest do
     end
 
     test "should return error when response is invalid" do
-      xml_response = File.read!("test/devices/fixtures/invalid_get_network_protocols_response.xml")
+      xml_response =
+        File.read!("test/devices/fixtures/invalid_get_network_protocols_response.xml")
+
       device = Onvif.Factory.device()
 
       Mimic.expect(Tesla, :request, fn _client, _opts ->

--- a/test/search/get_recording_summary_test.exs
+++ b/test/search/get_recording_summary_test.exs
@@ -13,13 +13,13 @@ defmodule Onvif.Search.GetRecordingSummaryTest do
         {:ok, %{status: 200, body: xml_response}}
       end)
 
-      {:ok, response} =
-        Onvif.Search.GetRecordingSummary.request(device)
+      {:ok, response} = Onvif.Search.GetRecordingSummary.request(device)
 
       assert response == %{
-        data_from: "1970-01-01T00:00:00Z",
-        data_until: "2024-12-13T08:08:49Z",
-        number_recordings: "8"}
+               data_from: "1970-01-01T00:00:00Z",
+               data_until: "2024-12-13T08:08:49Z",
+               number_recordings: "8"
+             }
     end
   end
 end


### PR DESCRIPTION
Currently you cannot request all the video encoder configurations compatible with a certain profile without providing `configuration token`
```elixir
Onvif.Media.Ver20.GetVideoEncoderConfigurations.request(device, [nil, "profile0"])
```

always returns an error