### PR TITLE
update to elixir 1.14

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.4-otp-25
+elixir 1.14.5-otp-25
 erlang 25.2.3

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Onvif.MixProject do
     [
       app: :onvif,
       version: "0.5.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
 


### PR DESCRIPTION
Some deps require 1.14 or higher, will incrementally update and bump releases

this will be included in 0.5.0