### PR TITLE
Group modules in hex docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Onvif
 
+[![Hex.pm](https://img.shields.io/hexpm/v/onvif.svg)](https://hex.pm/packages/onvif)
+[![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](https://hexdocs.pm/onvif)
+
 **Elixir interface for Onvif functions**
 
 ## Installation

--- a/lib/discovery.ex
+++ b/lib/discovery.ex
@@ -23,7 +23,19 @@ defmodule Onvif.Discovery do
   @onvif_scope_prefix "onvif://www.onvif.org/"
 
   defmodule Probe do
-    @type t :: %__MODULE__{}
+    @moduledoc """
+    A struct representing a discovered device.
+    """
+
+    @type t :: %__MODULE__{
+            types: [String.t()],
+            scopes: [String.t()],
+            request_guid: String.t(),
+            address: [String.t()],
+            device_ip: String.t(),
+            device_port: pos_integer()
+          }
+
     @derive Jason.Encoder
     defstruct [:types, :scopes, :request_guid, :address, :device_ip, :device_port]
   end

--- a/lib/factory.ex
+++ b/lib/factory.ex
@@ -1,4 +1,6 @@
 defmodule Onvif.Factory do
+  @moduledoc false
+
   def device do
     %Onvif.Device{
       address: "http://192.168.254.89",

--- a/lib/middleware/digest_auth.ex
+++ b/lib/middleware/digest_auth.ex
@@ -1,9 +1,8 @@
 defmodule Onvif.Middleware.DigestAuth do
-  @moduledoc """
-  This is a direct fork of the `Tesla.Middleware.DigestAuth`, which, does not build the
-  [digest-response](https://datatracker.ietf.org/doc/html/rfc2617#section-3.2.2) in the order that
-  the UniView LAPI accepts/understands.
-  """
+  @moduledoc false
+  # This is a direct fork of the `Tesla.Middleware.DigestAuth`, which, does not build the
+  # [digest-response](https://datatracker.ietf.org/doc/html/rfc2617#section-3.2.2) in the order that
+  # the UniView LAPI accepts/understands.
 
   @behaviour Tesla.Middleware
 

--- a/lib/middleware/digest_auth.ex
+++ b/lib/middleware/digest_auth.ex
@@ -1,8 +1,5 @@
 defmodule Onvif.Middleware.DigestAuth do
   @moduledoc false
-  # This is a direct fork of the `Tesla.Middleware.DigestAuth`, which, does not build the
-  # [digest-response](https://datatracker.ietf.org/doc/html/rfc2617#section-3.2.2) in the order that
-  # the UniView LAPI accepts/understands.
 
   @behaviour Tesla.Middleware
 

--- a/lib/middleware/no_auth.ex
+++ b/lib/middleware/no_auth.ex
@@ -1,6 +1,5 @@
 defmodule Onvif.Middleware.NoAuth do
-  @moduledoc """
-  """
+  @moduledoc false
 
   @behaviour Tesla.Middleware
   import XmlBuilder

--- a/lib/middleware/plain_auth.ex
+++ b/lib/middleware/plain_auth.ex
@@ -1,6 +1,5 @@
 defmodule Onvif.Middleware.PlainAuth do
-  @moduledoc """
-  """
+  @moduledoc false
 
   @behaviour Tesla.Middleware
   import XmlBuilder

--- a/lib/middleware/xml_auth.ex
+++ b/lib/middleware/xml_auth.ex
@@ -1,6 +1,5 @@
 defmodule Onvif.Middleware.XmlAuth do
-  @moduledoc """
-  """
+  @moduledoc false
 
   @behaviour Tesla.Middleware
   import XmlBuilder

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,8 @@
 defmodule Onvif.MixProject do
   use Mix.Project
 
+  @github_url "https://github.com/hammeraj/onvif"
+
   def project do
     [
       app: :onvif,
@@ -11,16 +13,14 @@ defmodule Onvif.MixProject do
 
       # ex_doc / hex
       name: "Onvif",
-      source_url: "https://github.com/hammeraj/onvif",
+      source_url: @github_url,
       description: "Elixir interface for Onvif functions",
-      docs: [
-        # The main page in the docs
-        main: "Onvif",
-        extras: ["README.md"]
-      ],
+      docs: docs(),
       package: [
         licenses: ["BSD-3-Clause"],
-        links: []
+        links: %{
+          "GitHub" => @github_url
+        }
       ]
     ]
   end
@@ -44,6 +44,55 @@ defmodule Onvif.MixProject do
       {:xml_builder, "~> 2.3"},
       {:jason, "~> 1.4"},
       {:mimic, "~> 1.7.4", only: :test}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "Onvif",
+      extras: ["README.md"],
+      nest_modules_by_prefix: [
+        Onvif.Device,
+        Onvif.Devices,
+        Onvif.Devices.Schemas,
+        Onvif.Media.Ver10,
+        Onvif.Media.Ver10.Schemas,
+        Onvif.Media.Ver20,
+        Onvif.Media.Ver20.Schemas,
+        Onvif.Recording,
+        Onvif.Recording.Schemas,
+        Onvif.Replay,
+        Onvif.Replay.Schemas,
+        Onvif.Search,
+        Onvif.Search.Schemas
+      ],
+      groups_for_modules: [
+        Core: [
+          Onvif,
+          ~r/^Onvif.Discovery.*/,
+          Onvif.Device,
+          Onvif.MacAddress,
+          Onvif.Request
+        ],
+        "Device Management": [
+          ~r/^Onvif.Devices.*/
+        ],
+        Media10: [
+          ~r/^Onvif.Media.Ver10.*/
+        ],
+        Media20: [
+          ~r/^Onvif.Media.Ver20.*/
+        ],
+        Recording: [
+          ~r/^Onvif.Recording.*/
+        ],
+        Replay: [
+          ~r/^Onvif.Replay.*/
+        ],
+        Search: [
+          ~r/^Onvif.Search.*/
+        ]
+      ]
     ]
   end
 end


### PR DESCRIPTION
I find the documentation hard to navigate with all this modules, so in this PR I grouped the modules:

- `Core` - contains core modules.
- `Device Management` - contains operations and schemas for device management
- `Media10` - contains operations and schemas for media version 1.0
- ...etc.

I also made the `middlewares` private since they'll not be used by the users of this lib.
`Onvif.Factory` is mainly used for tests, so I thought of moving it to `test/support`, however I saw there's `.gitignore` for that folder, so I left it there.